### PR TITLE
Fix Window Insets

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,42 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
 
     <com.boolder.boolder.view.map.BoolderMap
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:contentDescription="@string/cd_find_my_position"
-        android:id="@+id/fab_location"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="20dp"
-        android:layout_marginBottom="30dp"
-        android:backgroundTint="@color/white"
-        android:src="@drawable/ic_fab_near_me"
-        app:borderWidth="0dp"
-        app:fabSize="mini"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <androidx.fragment.app.FragmentContainerView xmlns:tools="http://schemas.android.com/tools"
-        android:id="@+id/host_fragment"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".view.map.MapActivity" />
+        android:fitsSystemWindows="true">
 
-    <include
-        android:id="@+id/search_component"
-        layout="@layout/search_component"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="36dp"
-        app:layout_constraintTop_toTopOf="parent" />
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_location"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:backgroundTint="@color/white"
+            android:contentDescription="@string/cd_find_my_position"
+            android:src="@drawable/ic_fab_near_me"
+            app:borderWidth="0dp"
+            app:fabSize="mini"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.fragment.app.FragmentContainerView xmlns:tools="http://schemas.android.com/tools"
+            android:id="@+id/host_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:context=".view.map.MapActivity" />
 
+        <include
+            android:id="@+id/search_component"
+            layout="@layout/search_component"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="16dp"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</FrameLayout>

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -6,14 +6,22 @@
     android:background="@color/gray"
     android:layout_height="match_parent">
 
-    <include
-        android:id="@+id/search_component"
-        layout="@layout/search_component"
+    <FrameLayout
+        android:id="@+id/search_component_wrapper"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="12dp"
-        android:layout_marginTop="36dp"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:fitsSystemWindows="true"
+        android:clipToPadding="false"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <include
+            android:id="@+id/search_component"
+            layout="@layout/search_component"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="16dp" />
+    </FrameLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
@@ -22,7 +30,7 @@
         android:layout_marginTop="8dp"
         android:background="@color/gray"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/search_component" />
+        app:layout_constraintTop_toBottomOf="@+id/search_component_wrapper" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/suggestion_container"
@@ -89,7 +97,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/suggestion_second"
             tools:text="Isatis" />
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
👋 Very nice app! Here is my little contribution:

# Why ?

The current layout doesn't take into account Display cutouts:

| Main | Search |
| - | - |
|<img src=https://user-images.githubusercontent.com/1233069/216538343-b637f615-335b-4cfd-bb4c-61c3af0dbc0f.png width=300 />|<img src=https://user-images.githubusercontent.com/1233069/216538322-03afa3f9-03b1-452d-bec8-8de7ebbf1ecc.png width=300 />|

# Suggestion

- Apply `fitsSystemWindows` on a content wrapper
- Adjust margins to align the Floating Action Button with the Search Bar

| Main | Search |
| - | - |
|<img src=https://user-images.githubusercontent.com/1233069/216538332-391bc16e-e3cb-4448-8024-8225ad5eb322.png width=300 />|<img src=https://user-images.githubusercontent.com/1233069/216538330-6dea30ba-5fea-41ea-a1df-c059f9c17f64.png width=300 />|

# How to test

- On the Android emulator, we can enable fake cutouts in [developer options](https://developer.android.com/develop/ui/views/layout/display-cutout#test_how_your_content_renders)