### PR TITLE
Fix search component top inset

### DIFF
--- a/app/src/main/java/com/boolder/boolder/utils/extension/ViewExtensions.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/extension/ViewExtensions.kt
@@ -1,0 +1,14 @@
+package com.boolder.boolder.utils.extension
+
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+fun View.setOnApplyWindowTopInsetListener(block: (topInset: Int) -> Unit) {
+    ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
+        val topInset = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
+
+        block(topInset)
+        insets
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
@@ -6,11 +6,14 @@ import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
+import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityOptionsCompat
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updateMargins
 import androidx.lifecycle.lifecycleScope
 import com.boolder.boolder.R
 import com.boolder.boolder.databinding.ActivityMainBinding
@@ -19,6 +22,7 @@ import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.utils.LocationCallback
 import com.boolder.boolder.utils.LocationProvider
 import com.boolder.boolder.utils.MapboxStyleFactory
+import com.boolder.boolder.utils.extension.setOnApplyWindowTopInsetListener
 import com.boolder.boolder.utils.viewBinding
 import com.boolder.boolder.view.detail.BottomSheetListener
 import com.boolder.boolder.view.detail.ProblemBSFragment
@@ -51,6 +55,15 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderClickListener,
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+
+        binding.root.setOnApplyWindowTopInsetListener { topInset ->
+            val topMargin = topInset + resources.getDimensionPixelSize(R.dimen.margin_search_component)
+
+            binding.searchComponent
+                .searchContainer
+                .updateLayoutParams<ViewGroup.MarginLayoutParams> { updateMargins(top = topMargin) }
+        }
+
         locationProvider = LocationProvider(this, this)
 
         setupMap()

--- a/app/src/main/java/com/boolder/boolder/view/search/SearchActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/search/SearchActivity.kt
@@ -3,8 +3,11 @@ package com.boolder.boolder.view.search
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updateMargins
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -13,6 +16,7 @@ import com.boolder.boolder.R
 import com.boolder.boolder.databinding.ActivitySearchBinding
 import com.boolder.boolder.utils.NetworkObserver
 import com.boolder.boolder.utils.NetworkObserverImpl
+import com.boolder.boolder.utils.extension.setOnApplyWindowTopInsetListener
 import com.boolder.boolder.utils.viewBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -50,6 +54,14 @@ class SearchActivity : AppCompatActivity(), NetworkObserver {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+
+        binding.root.setOnApplyWindowTopInsetListener { topInset ->
+            val topMargin = topInset + resources.getDimensionPixelSize(R.dimen.margin_search_component)
+
+            binding.searchComponent
+                .searchContainer
+                .updateLayoutParams<ViewGroup.MarginLayoutParams> { updateMargins(top = topMargin) }
+        }
 
         // Listen to network change
         networkObserverImpl.subscribeOn(this, this)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,7 +35,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="36dp"
+        android:layout_marginTop="@dimen/margin_search_component"
         app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -12,7 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="12dp"
-        android:layout_marginTop="36dp"
+        android:layout_marginTop="@dimen/margin_search_component"
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="margin_search_component">16dp</dimen>
+</resources>


### PR DESCRIPTION
The top inset was not properly handled for the search component in the
`MapActivity` not the `SearchActivity`.

This commit uses the `ViewCompat.setOnApplyWindowInsetsListener()`
function to properly dispatch the window insets and adapt the search
component adequately.

Before|After
-|-
<img src="https://user-images.githubusercontent.com/8343416/235364813-10aea1c6-3600-4567-9d62-6a3e5fcd6574.png" width=300 />|<img src="https://user-images.githubusercontent.com/8343416/235364802-c509005e-68f3-45f5-92a0-5b0e69dba3e0.png" width=300 />
<img src="https://user-images.githubusercontent.com/8343416/235364814-80524c46-d3a5-4385-b499-0e304f67f700.png" width=300 />|<img src="https://user-images.githubusercontent.com/8343416/235364808-2145de5f-9a8b-4e0b-a574-6b5c683ad3ab.png" width=300 />
<img src="https://user-images.githubusercontent.com/8343416/235364815-d6afc13e-9e83-4471-8009-acfad2ced54c.png" width=300 />|<img src="https://user-images.githubusercontent.com/8343416/235364809-769dcd07-d610-4762-ba50-b419daf48889.png" width=300 />
<img src="https://user-images.githubusercontent.com/8343416/235364818-4af21b86-b878-41a3-be18-c2cbd37012d6.png" width=300 />|<img src="https://user-images.githubusercontent.com/8343416/235364812-b78e07b5-da0e-409f-aca0-b9586c085fcf.png" width=300 />

Fixes #4
