### PR TITLE
Hide steepness info when empty

### DIFF
--- a/app/src/main/java/com/boolder/boolder/domain/model/Steepness.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/model/Steepness.kt
@@ -1,0 +1,46 @@
+package com.boolder.boolder.domain.model
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.boolder.boolder.R
+
+enum class Steepness(
+    @StringRes val textRes: Int?,
+    @DrawableRes val iconRes: Int?
+) {
+    SLAB(
+        textRes = R.string.stepness_slab,
+        iconRes = R.drawable.ic_steepness_slab
+    ),
+    OVERHANG(
+        textRes = R.string.stepness_overhang,
+        iconRes = R.drawable.ic_steepness_overhang
+    ),
+    ROOF(
+        textRes = R.string.stepness_roof,
+        iconRes = R.drawable.ic_steepness_roof
+    ),
+    WALL(
+        textRes = R.string.stepness_wall,
+        iconRes = R.drawable.ic_steepness_wall
+    ),
+    TRAVERSE(
+        textRes = R.string.stepness_traverse,
+        iconRes = R.drawable.ic_steepness_traverse_left_right
+    ),
+    OTHER(
+        textRes = null,
+        iconRes = null
+    );
+
+    companion object {
+        fun fromTextValue(value: String): Steepness = when (value.lowercase()) {
+            "slab" -> SLAB
+            "overhang" -> OVERHANG
+            "roof" -> ROOF
+            "wall" -> WALL
+            "traverse" -> TRAVERSE
+            else -> OTHER
+        }
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/view/detail/ProblemBSFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/ProblemBSFragment.kt
@@ -18,17 +18,16 @@ import android.widget.TextView
 import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
-import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
 import androidx.core.view.setPadding
-import androidx.fragment.app.findFragment
 import com.boolder.boolder.R
 import com.boolder.boolder.databinding.BottomSheetBinding
 import com.boolder.boolder.domain.model.CircuitColor
-import com.boolder.boolder.domain.model.CircuitColor.OFF_CIRCUIT
 import com.boolder.boolder.domain.model.CircuitColor.WHITE
 import com.boolder.boolder.domain.model.CompleteProblem
 import com.boolder.boolder.domain.model.Line
 import com.boolder.boolder.domain.model.Problem
+import com.boolder.boolder.domain.model.Steepness
 import com.boolder.boolder.utils.CubicCurveAlgorithm
 import com.boolder.boolder.utils.viewBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -37,7 +36,7 @@ import com.squareup.picasso.OkHttp3Downloader
 import com.squareup.picasso.Picasso
 import okhttp3.OkHttpClient
 import org.koin.android.ext.android.get
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.TimeUnit.SECONDS
 
 
@@ -159,38 +158,26 @@ class ProblemBSFragment(private val listener: BottomSheetListener) : BottomSheet
         binding.title.text = selectedProblem.nameSafe()
         binding.grade.text = selectedProblem.grade
 
-        val steepnessDrawable = when (selectedProblem.steepness) {
-            "slab" -> R.drawable.ic_steepness_slab
-            "overhang" -> R.drawable.ic_steepness_overhang
-            "roof" -> R.drawable.ic_steepness_roof
-            "wall" -> R.drawable.ic_steepness_wall
-            "traverse" -> R.drawable.ic_steepness_traverse_left_right
-            else -> null
-        }?.let {
-            ContextCompat.getDrawable(requireContext(), it)
-        }
-        binding.typeIcon.setImageDrawable(steepnessDrawable)
+        val steepness = Steepness.fromTextValue(selectedProblem.steepness)
 
-        var steepnessText: String? = null
-        when (selectedProblem.steepness) {
-            "slab" -> R.string.stepness_slab
-            "overhang" -> R.string.stepness_overhang
-            "roof" -> R.string.stepness_roof
-            "wall" -> R.string.stepness_wall
-            "traverse" -> R.string.stepness_traverse
-            else -> null
-        }?.let {
-            steepnessText = getString(it)
+        binding.typeIcon.apply {
+            val steepnessDrawable = steepness.iconRes
+                ?.let { ContextCompat.getDrawable(context, it) }
+
+            setImageDrawable(steepnessDrawable)
+            isVisible = steepnessDrawable != null
         }
 
-        val sitStartText = if (selectedProblem.sitStart) {
-            requireContext().getString(R.string.sit_start)
-        } else null
+        binding.typeText.apply {
+            val steepnessText = steepness.textRes?.let(::getString)
 
-        binding.typeText.text = listOf(steepnessText, sitStartText).filterNotNull().joinToString(separator = " • ")
+            val sitStartText = if (selectedProblem.sitStart) {
+                resources.getString(R.string.sit_start)
+            } else null
 
-        binding.typeIcon.visibility = if(selectedProblem.steepness.contains("other", true)) View.INVISIBLE else View.VISIBLE
-        binding.typeText.visibility = if(binding.typeText.text == null) View.GONE else View.VISIBLE
+            text = listOfNotNull(steepnessText, sitStartText).joinToString(separator = " • ")
+            isVisible = !text.isNullOrEmpty()
+        }
     }
 
     private fun setupChipClick() {

--- a/app/src/main/res/layout/bottom_sheet.xml
+++ b/app/src/main/res/layout/bottom_sheet.xml
@@ -41,9 +41,9 @@
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
         android:ellipsize="end"
+        android:textColor="@color/black"
         android:textSize="26sp"
         android:textStyle="bold"
-        android:textColor="@color/black"
         app:layout_constraintEnd_toStartOf="@+id/grade"
         app:layout_constraintHorizontal_bias="1"
         app:layout_constraintHorizontal_chainStyle="spread"
@@ -56,9 +56,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="10dp"
+        android:textColor="@color/black"
         android:textSize="26sp"
         android:textStyle="bold"
-        android:textColor="@color/black"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/title"
         app:layout_constraintTop_toBottomOf="@+id/picture"
@@ -69,24 +69,22 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_margin="8dp"
-        android:layout_marginBottom="8dp"
         android:contentDescription="@string/cd_type"
+        app:layout_constraintBottom_toBottomOf="@+id/type_text"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/title"
-        tools:src="@drawable/ic_steepness_overhang"
-        tools:text="5a"
-        app:tint="@color/black" />
+        app:layout_constraintTop_toTopOf="@+id/type_text"
+        app:tint="@color/black"
+        tools:src="@drawable/ic_steepness_overhang" />
 
     <TextView
         android:id="@+id/type_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:textSize="18sp"
+        android:layout_margin="8dp"
         android:textColor="@color/black"
-        app:layout_constraintBottom_toBottomOf="@id/type_icon"
+        android:textSize="18sp"
         app:layout_constraintStart_toEndOf="@+id/type_icon"
-        app:layout_constraintTop_toTopOf="@id/type_icon"
+        app:layout_constraintTop_toBottomOf="@+id/title"
         tools:text="Wall" />
 
     <com.google.android.material.chip.Chip


### PR DESCRIPTION
There is no empty space anymore when there is no steepness to display

Before | After
-|-
<img src="https://github.com/boolder-org/boolder-android/assets/8343416/bf3bdd1c-324c-4566-a750-ac1639a12ba2" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/75c1824c-6db9-440e-9886-19469ac5f3dc" width=300 />
<img src="https://github.com/boolder-org/boolder-android/assets/8343416/c5ed3e24-6914-4aca-b456-3ffb8d4c40b9" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/2d0edfc0-14df-4dd8-8e6e-754b807ef4de" width=300 />
<img src="https://github.com/boolder-org/boolder-android/assets/8343416/ae82558c-3506-46c0-97a4-55304867816e" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/e10e5216-238d-4155-a3fa-5a7df9b89400" width=300 />

Fixes #15 