### PR TITLE
Add shadow under boulder problem line

### DIFF
--- a/app/src/main/java/com/boolder/boolder/domain/model/CircuitColor.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/model/CircuitColor.kt
@@ -1,6 +1,7 @@
 package com.boolder.boolder.domain.model
 
 import android.content.Context
+import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 import com.boolder.boolder.R
 import com.mapbox.maps.extension.style.expressions.generated.Expression.ExpressionBuilder
@@ -52,6 +53,7 @@ enum class CircuitColor {
         return context.getString(id)
     }
 
+    @ColorInt
     fun getColor(context: Context): Int {
         val id = when (this) {
             YELLOW -> R.color.circuit_color_yellow

--- a/app/src/main/java/com/boolder/boolder/domain/model/Problem.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/model/Problem.kt
@@ -2,6 +2,7 @@ package com.boolder.boolder.domain.model
 
 import android.content.Context
 import android.os.Parcelable
+import androidx.annotation.ColorInt
 import com.boolder.boolder.view.search.BaseObject
 import kotlinx.parcelize.Parcelize
 
@@ -30,6 +31,7 @@ data class Problem(
         get() = circuitColor?.let { CircuitColor.valueOf(it.uppercase()) }
             ?: CircuitColor.OFF_CIRCUIT
 
-    fun drawColor(context: Context): Int = circuitColorSafe.getColor(context)
+    @ColorInt
+    fun getColor(context: Context): Int = circuitColorSafe.getColor(context)
 
 }

--- a/app/src/main/java/com/boolder/boolder/view/detail/ProblemLineView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/ProblemLineView.kt
@@ -1,16 +1,21 @@
 package com.boolder.boolder.view.detail
 
 import android.content.Context
-import android.graphics.*
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.PointF
 import android.util.AttributeSet
 import android.util.Log
 import android.util.TypedValue
 import android.view.View
-import androidx.annotation.ColorRes
+import androidx.annotation.ColorInt
+import androidx.core.content.ContextCompat
+import com.boolder.boolder.R
 
 
-class LineVectorView @JvmOverloads constructor(
-    context: Context?,
+class ProblemLineView @JvmOverloads constructor(
+    context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : View(context, attrs, defStyleAttr) {
@@ -27,34 +32,22 @@ class LineVectorView @JvmOverloads constructor(
         )
     }
 
-    private val paint = Paint()
-
-    private var viewCanvas: Canvas? = null
-    private var bitmap: Bitmap? = null
-    private val bitmapPaint = Paint(Paint.DITHER_FLAG)
-
-    override fun onSizeChanged(
-        w: Int,
-        h: Int,
-        oldw: Int,
-        oldh: Int
-    ) {
-        super.onSizeChanged(w, h, oldw, oldh)
-
-        bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
-        viewCanvas = Canvas(bitmap!!)
+    private val paint = Paint().apply {
+        setShadowLayer(
+            resources.getDimension(R.dimen.radius_problem_line),
+            0f,
+            0f,
+            ContextCompat.getColor(context, R.color.problem_line_shadow)
+        )
+        setLayerType(LAYER_TYPE_SOFTWARE, this)
     }
 
-    override fun onDraw(canvas: Canvas?) {
+    override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
-
-        drawBezierCurve(canvas)
-        bitmap?.let {
-            canvas?.drawBitmap(it, 0f, 0f, bitmapPaint)
-        }
+        canvas.drawProblemPath()
     }
 
-    private fun drawBezierCurve(canvas: Canvas?) {
+    private fun Canvas.drawProblemPath() {
         try {
             if (points.isEmpty() && controlPoint1.isEmpty() && controlPoint2.isEmpty()) return
 
@@ -72,14 +65,19 @@ class LineVectorView @JvmOverloads constructor(
                 )
             }
 
-            canvas?.drawPath(path, paint)
+            drawPath(path, paint)
 
         } catch (e: Exception) {
             Log.e("TAG", e.message ?: "")
         }
     }
 
-    fun addDataPoints(data: List<PointD>, point1: List<PointD>, point2: List<PointD>, @ColorRes drawColor: Int) {
+    fun addDataPoints(
+        data: List<PointD>,
+        point1: List<PointD>,
+        point2: List<PointD>,
+        @ColorInt drawColor: Int
+    ) {
 
         paint.apply {
             isAntiAlias = true

--- a/app/src/main/java/com/boolder/boolder/view/detail/ProblemStartView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/ProblemStartView.kt
@@ -1,0 +1,79 @@
+package com.boolder.boolder.view.detail
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.annotation.ColorInt
+import androidx.core.content.ContextCompat
+import androidx.core.view.updateLayoutParams
+import com.boolder.boolder.R
+import com.boolder.boolder.databinding.ViewProblemStartBinding
+
+class ProblemStartView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+): FrameLayout(context, attrs, defStyleAttr) {
+
+    private val binding = ViewProblemStartBinding.inflate(LayoutInflater.from(context), this)
+
+    private val paint = Paint().apply {
+        style = Paint.Style.FILL_AND_STROKE
+        isAntiAlias = true
+
+        setShadowLayer(
+            resources.getDimension(R.dimen.radius_problem_line),
+            0f,
+            0f,
+            ContextCompat.getColor(context, R.color.problem_line_shadow)
+        )
+        setLayerType(LAYER_TYPE_SOFTWARE, this)
+    }
+
+    private var radius = resources.getDimension(R.dimen.size_problem_start_without_number) / 2f
+
+    init {
+        setWillNotDraw(false)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        canvas.drawDiscBackground()
+        super.onDraw(canvas)
+    }
+
+    fun setText(text: CharSequence?) {
+        val sizeRes = if (text == null) {
+            R.dimen.size_problem_start_without_number
+        } else {
+            R.dimen.size_problem_start_with_number
+        }
+
+        val size = resources.getDimensionPixelSize(sizeRes)
+
+        binding.background.updateLayoutParams<ViewGroup.LayoutParams> {
+            width = size
+            height = size
+        }
+
+        binding.textView.text = text
+        radius = size / 2f
+        invalidate()
+    }
+
+    fun setTextColor(@ColorInt color: Int) {
+        binding.textView.setTextColor(color)
+    }
+
+    fun setProblemColor(@ColorInt color: Int) {
+        paint.color = color
+        invalidate()
+    }
+
+    private fun Canvas.drawDiscBackground() {
+        drawCircle(width / 2f, width / 2f, radius, paint)
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/view/search/viewholder/ProblemViewHolder.kt
+++ b/app/src/main/java/com/boolder/boolder/view/search/viewholder/ProblemViewHolder.kt
@@ -31,7 +31,7 @@ class ProblemViewHolder private constructor(
 
             circuitNumber.setTextColor(ColorStateList.valueOf(textColor))
             circuitColor.backgroundTintList =
-                ColorStateList.valueOf(problem.drawColor(root.context))
+                ColorStateList.valueOf(problem.getColor(root.context))
         }
     }
 

--- a/app/src/main/res/layout/bottom_sheet.xml
+++ b/app/src/main/res/layout/bottom_sheet.xml
@@ -27,13 +27,12 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.boolder.boolder.view.detail.LineVectorView
+    <com.boolder.boolder.view.detail.ProblemLineView
         android:id="@+id/line_vector"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintDimensionRatio="4:3"
         app:layout_constraintTop_toTopOf="parent" />
-
 
     <TextView
         android:id="@+id/title"

--- a/app/src/main/res/layout/view_problem_start.xml
+++ b/app/src/main/res/layout/view_problem_start.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    tools:parentTag="android.widget.FrameLayout">
+
+    <FrameLayout
+        android:id="@+id/background"
+        android:layout_width="@dimen/size_problem_start_with_number"
+        android:layout_height="@dimen/size_problem_start_with_number"
+        android:layout_gravity="center"
+        android:layout_margin="@dimen/margin_problem_start"
+        tools:background="@color/circuit_color_red">
+
+        <TextView
+            android:id="@+id/text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textAlignment="center"
+            android:textColor="@color/white"
+            android:textSize="18sp"
+            tools:text="42" />
+
+    </FrameLayout>
+
+</merge>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -30,4 +30,6 @@
     <color name="circuit_color_white_for_kids">#FFFFFF</color>
     <color name="circuit_color_black">#000000</color>
     <color name="circuit_color_off_circuit">#CCCCCC</color>
+
+    <color name="problem_line_shadow">#99333333</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,4 +5,10 @@
 
     <dimen name="margin_compass_top">80dp</dimen>
     <dimen name="margin_compass_end">16dp</dimen>
+
+    <dimen name="margin_problem_start">4dp</dimen>
+    <dimen name="size_problem_start_with_number">28dp</dimen>
+    <dimen name="size_problem_start_without_number">16dp</dimen>
+    <dimen name="radius_problem_line">2dp</dimen>
+
 </resources>


### PR DESCRIPTION
A shadow was needed in order to improve the contrast on the boulder problem line.
To do so, a dedicated custom view has been created for the boulder start point (`ProblemStartView`)

Before | After
-|-
<img src="https://github.com/boolder-org/boolder-android/assets/8343416/2b87392b-2bcb-44db-9ab7-94603045c2e5" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/9132749c-aabe-4d72-890f-69303bab24bf" width=300 />
<img src="https://github.com/boolder-org/boolder-android/assets/8343416/eae4f1fd-c300-48b2-8352-7a218d4fc02d" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/0592c967-747c-4d67-83ef-9b0471353271" width=300 />
<img src="https://github.com/boolder-org/boolder-android/assets/8343416/40248786-25ae-499e-bbbe-694f683f8e89" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/52eb09ef-d284-4153-9bdd-aef48d198e5d" width=300 />

Fixes #17 