### PR TITLE
Make bottom sheet not modal

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/detail/ProblemLineView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/ProblemLineView.kt
@@ -110,9 +110,9 @@ class ProblemLineView @JvmOverloads constructor(
                 controlPoint1.clear()
                 controlPoint2.clear()
 
-                points.addAll(data.toF())
-                controlPoint1.addAll(point1.toF())
-                controlPoint2.addAll(point2.toF())
+                points.addAll(data.toPointFList())
+                controlPoint1.addAll(point1.toPointFList())
+                controlPoint2.addAll(point2.toPointFList())
 
                 postInvalidate()
 
@@ -121,6 +121,7 @@ class ProblemLineView @JvmOverloads constructor(
     }
 
     fun clearPath() {
+        lineLengthRatio = 0f
         points.clear()
         controlPoint1.clear()
         controlPoint2.clear()
@@ -141,3 +142,7 @@ class ProblemLineView @JvmOverloads constructor(
         }
     }
 }
+
+data class PointD(val x: Double, val y: Double)
+
+fun List<PointD>.toPointFList() = map { PointF(it.x.toFloat(), it.y.toFloat()) }

--- a/app/src/main/java/com/boolder/boolder/view/detail/ProblemView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/ProblemView.kt
@@ -193,6 +193,8 @@ class ProblemView(
     }
 
     private fun loadBoolderImage() {
+        binding.progressCircular.isVisible = true
+
         if (completeProblem?.topo != null) {
             val okHttpClient = OkHttpClient.Builder()
                 .connectTimeout(10, SECONDS)
@@ -207,7 +209,7 @@ class ProblemView(
                     override fun onSuccess() {
                         context?.let {
                             binding.picture.setPadding(0)
-                            binding.progressCircular.visibility = View.GONE
+                            binding.progressCircular.isVisible = false
                             markParentAsSelected()
                         }
                     }
@@ -224,7 +226,7 @@ class ProblemView(
             ContextCompat.getDrawable(context, R.drawable.ic_placeholder)
         )
         binding.picture.setPadding(200)
-        binding.progressCircular.visibility = View.GONE
+        binding.progressCircular.isVisible = false
     }
     //endregion
 

--- a/app/src/main/java/com/boolder/boolder/view/detail/ProblemView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/ProblemView.kt
@@ -1,104 +1,93 @@
 package com.boolder.boolder.view.detail
 
+import android.content.Context
 import android.content.Intent
 import android.graphics.Color
-import android.graphics.PointF
 import android.net.Uri
-import android.os.Bundle
+import android.util.AttributeSet
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
-import android.widget.Button
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
-import androidx.core.os.bundleOf
+import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
 import com.boolder.boolder.R
-import com.boolder.boolder.databinding.BottomSheetBinding
+import com.boolder.boolder.databinding.ViewProblemBinding
 import com.boolder.boolder.domain.model.CircuitColor
 import com.boolder.boolder.domain.model.CompleteProblem
 import com.boolder.boolder.domain.model.Line
 import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.domain.model.Steepness
 import com.boolder.boolder.utils.CubicCurveAlgorithm
-import com.boolder.boolder.utils.viewBinding
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.squareup.picasso.Callback
 import com.squareup.picasso.OkHttp3Downloader
 import com.squareup.picasso.Picasso
 import okhttp3.OkHttpClient
-import org.koin.android.ext.android.get
 import java.util.Locale
 import java.util.concurrent.TimeUnit.SECONDS
 
+class ProblemView(
+    context: Context,
+    attrs: AttributeSet?
+) : ConstraintLayout(context, attrs) {
 
-interface BottomSheetListener {
-    fun onProblemSelected(problem: Problem)
-}
+    private val binding = ViewProblemBinding.inflate(LayoutInflater.from(context), this)
 
-class ProblemBSFragment(private val listener: BottomSheetListener) : BottomSheetDialogFragment() {
+    private var completeProblem: CompleteProblem? = null
 
-    companion object {
-        private const val COMPLETE_PROBLEM = "COMPLETE_PROBLEM"
-        fun newInstance(problem: CompleteProblem, listener: BottomSheetListener) = ProblemBSFragment(listener).apply {
-            arguments = bundleOf(COMPLETE_PROBLEM to problem)
-        }
-    }
-
-    private val binding: BottomSheetBinding by viewBinding(BottomSheetBinding::bind)
-    private val curveAlgorithm: CubicCurveAlgorithm
-        get() = get()
-
-    private val completeProblem
-        get() = requireArguments().getParcelable<CompleteProblem>(COMPLETE_PROBLEM)
-            ?: error("No Problem in arguments")
-
-    private lateinit var selectedProblem: Problem
+    private var selectedProblem: Problem? = null
     private var selectedLine: Line? = null
 
     private val bleauUrl
-        get() = "https://bleau.info/a/${selectedProblem.bleauInfoId}.html"
+        get() = selectedProblem?.bleauInfoId?.let { "https://bleau.info/a/$it.html" }
     private val shareUrl
-        get() = "https://www.boolder.com/${Locale.getDefault().language}/p/${selectedProblem.id}"
+        get() = selectedProblem?.id?.let { "https://www.boolder.com/${Locale.getDefault().language}/p/$it" }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.bottom_sheet, container, false)
+    init {
+        setBackgroundColor(Color.WHITE)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        selectedLine = completeProblem.line
-        selectedProblem = completeProblem.problem
-        hideBleauButton(view)
+    fun setProblem(problem: CompleteProblem) {
+        completeProblem = problem
+        selectedLine = completeProblem?.line
+        selectedProblem = completeProblem?.problem
+
+        children.filterIsInstance<ProblemStartView>()
+            .forEach(::removeView)
+
+        binding.lineVector.clearPath()
+
+        hideBleauButton()
         loadBoolderImage()
         updateLabels()
         setupChipClick()
     }
 
     private fun markParentAsSelected() {
-        selectedLine = completeProblem.line
-        selectedProblem = completeProblem.problem
+        selectedLine = completeProblem?.line
+        selectedProblem = completeProblem?.problem
         drawCurves()
         drawCircuitNumberCircle()
         updateLabels()
     }
 
-    private fun hideBleauButton(view: View) {
-        if(selectedProblem.bleauInfoId.isNullOrEmpty()) {
-            val bleauInfo = view.findViewById<Button>(R.id.bleau_info)
-            bleauInfo.visibility = View.GONE
+    private fun hideBleauButton() {
+        if (selectedProblem?.bleauInfoId.isNullOrEmpty()) {
+            binding.bleauInfo.visibility = View.GONE
         }
     }
 
     //region Draw
     private fun drawCurves() {
         val points = selectedLine?.points()
-        if (!points.isNullOrEmpty()) {
 
-            val segment = curveAlgorithm.controlPointsFromPoints(points)
+        if (!points.isNullOrEmpty()) {
+            val problemColor = selectedProblem?.getColor(context) ?: return
+
+            val segment = CubicCurveAlgorithm().controlPointsFromPoints(points)
 
             val ctrl1 = segment.map { PointD(it.controlPoint1.x, it.controlPoint1.y) }
             val ctrl2 = segment.map { PointD(it.controlPoint2.x, it.controlPoint2.y) }
@@ -108,7 +97,7 @@ class ProblemBSFragment(private val listener: BottomSheetListener) : BottomSheet
                     data = points,
                     point1 = ctrl1,
                     point2 = ctrl2,
-                    drawColor = selectedProblem.getColor(requireContext())
+                    drawColor = problemColor
                 )
                 animatePath()
             }
@@ -120,7 +109,7 @@ class ProblemBSFragment(private val listener: BottomSheetListener) : BottomSheet
     private fun drawCircuitNumberCircle() {
         val pointD = selectedLine?.points()?.firstOrNull()
         if (pointD != null) {
-            val viewSizeRes = if (selectedProblem.circuitNumber.isNullOrBlank()) {
+            val viewSizeRes = if (selectedProblem?.circuitNumber.isNullOrBlank()) {
                 R.dimen.size_problem_start_without_number
             } else {
                 R.dimen.size_problem_start_with_number
@@ -131,32 +120,33 @@ class ProblemBSFragment(private val listener: BottomSheetListener) : BottomSheet
             val viewWithMarginSize = viewSize + marginProblemStart * 2
             val offset = viewWithMarginSize / 2
 
-            val textColor = when (selectedProblem.circuitColorSafe) {
+            val textColor = when (selectedProblem?.circuitColorSafe) {
                 CircuitColor.WHITE -> Color.BLACK
                 else -> Color.WHITE
             }
 
             val problemStartView = ProblemStartView(binding.root.context).apply {
-                setText(selectedProblem.circuitNumber)
+                setText(selectedProblem?.circuitNumber)
                 setTextColor(textColor)
-                setProblemColor(selectedProblem.getColor(context))
+                selectedProblem?.getColor(context)?.let(::setProblemColor)
                 translationX = (pointD.x * binding.picture.measuredWidth - offset).toFloat()
                 translationY = (pointD.y * binding.picture.measuredHeight - offset).toFloat()
             }
 
-            binding.root.addView(problemStartView, LayoutParams(WRAP_CONTENT, WRAP_CONTENT))
+            addView(problemStartView, LayoutParams(WRAP_CONTENT, WRAP_CONTENT))
         }
     }
     //endregion
 
     private fun updateLabels() {
-        binding.title.text = selectedProblem.nameSafe()
-        binding.grade.text = selectedProblem.grade
+        binding.title.text = selectedProblem?.nameSafe()
+        binding.grade.text = selectedProblem?.grade
 
-        val steepness = Steepness.fromTextValue(selectedProblem.steepness)
+        val steepness = selectedProblem?.steepness?.let(Steepness::fromTextValue)
 
         binding.typeIcon.apply {
-            val steepnessDrawable = steepness.iconRes
+            val steepnessDrawable = steepness
+                ?.iconRes
                 ?.let { ContextCompat.getDrawable(context, it) }
 
             setImageDrawable(steepnessDrawable)
@@ -164,9 +154,9 @@ class ProblemBSFragment(private val listener: BottomSheetListener) : BottomSheet
         }
 
         binding.typeText.apply {
-            val steepnessText = steepness.textRes?.let(::getString)
+            val steepnessText = steepness?.textRes?.let(context::getString)
 
-            val sitStartText = if (selectedProblem.sitStart) {
+            val sitStartText = if (selectedProblem?.sitStart == true) {
                 resources.getString(R.string.sit_start)
             } else null
 
@@ -179,7 +169,7 @@ class ProblemBSFragment(private val listener: BottomSheetListener) : BottomSheet
         binding.bleauInfo.setOnClickListener {
             try {
                 val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(bleauUrl))
-                startActivity(browserIntent)
+                context.startActivity(browserIntent)
             } catch (e: Exception) {
                 Log.i("Bottom Sheet", "No apps can handle this kind of intent")
             }
@@ -195,47 +185,23 @@ class ProblemBSFragment(private val listener: BottomSheetListener) : BottomSheet
 
             try {
                 val shareIntent = Intent.createChooser(sendIntent, null)
-                startActivity(shareIntent)
+                context.startActivity(shareIntent)
             } catch (e: Exception) {
                 Log.i("Bottom Sheet", "No apps can handle this kind of intent")
             }
         }
-
-      /*  binding.reportIssue.setOnClickListener {
-            Intent(Intent.ACTION_SENDTO).apply {
-                data = Uri.parse("mailto:")
-                putExtra(Intent.EXTRA_EMAIL, listOf(getString(R.string.contact_mail)).toTypedArray())
-                putExtra(Intent.EXTRA_SUBJECT, "Feedback")
-                putExtra(
-                    Intent.EXTRA_TEXT, """
-                    =====
-                    Problem #${selectedProblem.id} - ${selectedProblem.nameSafe()}
-                    Boolder v.${BuildConfig.VERSION_NAME} (build n°${BuildConfig.VERSION_CODE})
-                    Android SDK ${Build.VERSION.SDK_INT} (${Build.VERSION.RELEASE})
-                    =====
-                    """.trimIndent()
-                )
-            }.run {
-                try {
-                    startActivity(this)
-                } catch (e: Exception) {
-                    Log.i("Bottom Sheet", "No apps can handle this kind of intent")
-                }
-            }
-        }*/
-
     }
 
     private fun loadBoolderImage() {
-        if (completeProblem.topo != null) {
+        if (completeProblem?.topo != null) {
             val okHttpClient = OkHttpClient.Builder()
                 .connectTimeout(10, SECONDS)
                 .build()
 
-            Picasso.Builder(requireContext())
+            Picasso.Builder(context)
                 .downloader(OkHttp3Downloader(okHttpClient))
                 .build()
-                .load(completeProblem.topo?.url)
+                .load(completeProblem?.topo?.url)
                 .error(R.drawable.ic_placeholder)
                 .into(binding.picture, object : Callback {
                     override fun onSuccess() {
@@ -254,30 +220,22 @@ class ProblemBSFragment(private val listener: BottomSheetListener) : BottomSheet
     }
 
     private fun loadErrorPicture() {
-        context?.let {
-            binding.picture.setImageDrawable(ContextCompat.getDrawable(it, R.drawable.ic_placeholder))
-            binding.picture.setPadding(200)
-            binding.progressCircular.visibility = View.GONE
-        }
+        binding.picture.setImageDrawable(
+            ContextCompat.getDrawable(context, R.drawable.ic_placeholder)
+        )
+        binding.picture.setPadding(200)
+        binding.progressCircular.visibility = View.GONE
     }
     //endregion
 
     //region Extensions
-    private fun Problem.nameSafe(): String {
-        if(Locale.getDefault().language == "fr") {
-            return name ?: ""
-        }
-        else {
-            return nameEn ?: ""
-        }
-    }
 
-    private fun String.localize(): String {
-        return CircuitColor.valueOf(this.uppercase()).localize(requireContext())
-    }
+    private fun Problem.nameSafe(): String =
+        if (Locale.getDefault().language == "fr") {
+            name.orEmpty()
+        } else {
+            nameEn.orEmpty()
+        }
+
     //endregion
 }
-
-data class PointD(val x: Double, val y: Double)
-
-fun List<PointD>.toF() = map { PointF(it.x.toFloat(), it.y.toFloat()) }

--- a/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
@@ -48,6 +48,7 @@ class BoolderMap @JvmOverloads constructor(
 
     interface BoolderClickListener {
         fun onProblemSelected(problemId: Int)
+        fun onProblemUnselected()
         fun onPoisSelected(poisName: String, stringProperty: String, geometry: Geometry?)
     }
 
@@ -154,7 +155,13 @@ class BoolderMap @JvmOverloads constructor(
         ) { features: Expected<String, MutableList<QueriedFeature>> ->
             if (features.isValue) {
 
-                val feature = features.value?.firstOrNull()?.feature ?: return@queryRenderedFeatures
+                val feature = features.value?.firstOrNull()?.feature
+                    ?: run {
+                        unselectProblem()
+                        listener?.onProblemUnselected()
+                        return@queryRenderedFeatures
+                    }
+
                 if (getMapboxMap().cameraState.zoom < 18) return@queryRenderedFeatures
                 if (feature.hasProperty("id") && feature.geometry() != null) {
                     selectProblem(feature.getNumberProperty("id").toString())

--- a/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
@@ -178,6 +178,10 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderClickListener 
         }
     }
 
+    override fun onProblemUnselected() {
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+    }
+
     override fun onPoisSelected(poisName: String, stringProperty: String, geometry: Geometry?) {
 
         val view = LayoutInflater.from(this).inflate(R.layout.bottom_sheet_pois, binding.root, false)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,48 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.boolder.boolder.view.map.BoolderMap
-        android:id="@+id/mapView"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent">
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/fab_location"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_map_controls"
-        android:layout_marginBottom="@dimen/margin_map_controls"
-        android:backgroundTint="@color/white"
-        android:contentDescription="@string/cd_find_my_position"
-        android:src="@drawable/ic_fab_near_me"
-        app:borderWidth="0dp"
-        app:fabSize="mini"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        <com.boolder.boolder.view.map.BoolderMap
+            android:id="@+id/mapView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
 
-    <include
-        android:id="@+id/search_component"
-        layout="@layout/search_component"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_location"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_map_controls"
+            android:layout_marginBottom="@dimen/margin_map_controls"
+            android:backgroundTint="@color/white"
+            android:contentDescription="@string/cd_find_my_position"
+            android:src="@drawable/ic_fab_near_me"
+            app:borderWidth="0dp"
+            app:fabSize="mini"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <include
+            android:id="@+id/search_component"
+            layout="@layout/search_component"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="@dimen/margin_search_component"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/grades_filter_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_map_controls"
+            app:icon="@drawable/ic_tune_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:text="Grades" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <FrameLayout
+        android:id="@+id/detail_bottom_sheet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="@dimen/margin_search_component"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:behavior_hideable="true"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/grades_filter_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_map_controls"
-        app:icon="@drawable/ic_tune_24"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        tools:text="Grades" />
+        <com.boolder.boolder.view.detail.ProblemView
+            android:id="@+id/problem_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </FrameLayout>
 
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/view_problem.xml
+++ b/app/src/main/res/layout/view_problem.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="10dp"
-    android:background="@color/bottom_sheet_background"
-    app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
+    app:layout_behavior="android.support.design.widget.BottomSheetBehavior"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <ImageView
         android:id="@+id/picture"
@@ -153,4 +153,4 @@
         app:layout_constraintStart_toEndOf="@id/save"
         app:layout_constraintTop_toBottomOf="@id/type_text" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>

--- a/app/src/main/res/layout/view_problem.xml
+++ b/app/src/main/res/layout/view_problem.xml
@@ -13,6 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:adjustViewBounds="true"
+        android:background="@color/gray"
         android:contentDescription="@string/cd_boolder_picture"
         app:layout_constraintDimensionRatio="4:3"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
The map was not interactive when a boulder detail was shown, because the bottom sheet was implemented as a modal bottom sheet.

The previous `ProblemBSFragment` has been changed to a `ProblemView` custom view, so that it can be part of the bottom sheet layout.

https://github.com/boolder-org/boolder-android/assets/8343416/9ca559b1-7169-4472-b76b-5667c73fb3b3

Resolves #18 