### PR TITLE
Set the Map Zoom Level to a Minimum on 17 on GPS Locate

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
@@ -45,6 +45,7 @@ import com.mapbox.maps.plugin.locationcomponent.location
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import java.lang.Double.max
 
 
 class MapActivity : AppCompatActivity(), LocationCallback, BoolderClickListener {
@@ -155,9 +156,10 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderClickListener 
 
     override fun onGPSLocation(location: Location) {
         val point = Point.fromLngLat(location.longitude, location.latitude)
+        val zoomLevel = max(binding.mapView.getMapboxMap().cameraState.zoom, 17.0)
 
         binding.mapView.getMapboxMap()
-            .setCamera(CameraOptions.Builder().center(point).zoom(16.0).bearing(location.bearing.toDouble()).build())
+            .setCamera(CameraOptions.Builder().center(point).zoom(zoomLevel).bearing(location.bearing.toDouble()).build())
         binding.mapView.location.updateSettings {
             enabled = true
             pulsingEnabled = true


### PR DESCRIPTION
When the GPS Locate button is clicked, the zoom level will be set to a minimum of 17

https://github.com/boolder-org/boolder-android/assets/23138767/b142edcd-37da-444c-b7f4-bebe671d69f1

resolves #29 