### PR TITLE
Display other problems on the photo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The app is written in Kotlin, and uses several libraries:
 - Room 
 - Mapbox SDK 
 - Koin 
-- Picasso
+- Coil
 
 Here is a 15-min video describing the architecture of the app : https://youtu.be/Qk7gX1CaMk4
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,8 +76,8 @@ dependencies {
     // DI
     implementation("io.insert-koin:koin-android:3.3.3")
 
-    // Picasso
-    implementation("com.squareup.picasso:picasso:2.8")
+    // Coil
+    implementation("io.coil-kt:coil:2.4.0")
 
     // Jetpack compose
     val composeBom = platform("androidx.compose:compose-bom:2023.09.00")

--- a/app/src/main/java/com/boolder/boolder/view/ViewModules.kt
+++ b/app/src/main/java/com/boolder/boolder/view/ViewModules.kt
@@ -1,7 +1,6 @@
 package com.boolder.boolder.view
 
 import android.content.res.Resources
-import com.boolder.boolder.utils.CubicCurveAlgorithm
 import com.boolder.boolder.utils.MapboxStyleFactory
 import com.boolder.boolder.utils.NetworkObserverImpl
 import com.boolder.boolder.view.map.MapViewModel
@@ -18,7 +17,6 @@ val viewModelModule = module {
     single { SearchViewModel(get(), get()) }
     single { NetworkObserverImpl() }
     factory { MapboxStyleFactory() }
-    factory { CubicCurveAlgorithm() }
 
     viewModelOf(::GradesFilterViewModel)
 }

--- a/app/src/main/java/com/boolder/boolder/view/detail/ProblemLineView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/ProblemLineView.kt
@@ -76,7 +76,7 @@ class ProblemLineView @JvmOverloads constructor(
             paint.pathEffect = DashPathEffect(
                 floatArrayOf(
                     length * lineLengthRatio,
-                    length * (1f - lineLengthRatio)
+                    length * 1f
                 ),
                 0f
             )

--- a/app/src/main/java/com/boolder/boolder/view/detail/ProblemView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/ProblemView.kt
@@ -33,6 +33,8 @@ class ProblemView(
 
     private val binding = ViewProblemBinding.inflate(LayoutInflater.from(context), this)
 
+    var onProblemFromSameTopoSelected: ((problemId: String) -> Unit)? = null
+
     init {
         setBackgroundColor(Color.WHITE)
         isClickable = true
@@ -59,6 +61,7 @@ class ProblemView(
         updateLabels(completeProblem.problem)
         setupChipClick(completeProblem.problem)
         drawCurves(completeProblem)
+        onProblemFromSameTopoSelected?.invoke(completeProblem.problem.id.toString())
     }
 
     //region Draw

--- a/app/src/main/java/com/boolder/boolder/view/detail/ProblemView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/ProblemView.kt
@@ -12,6 +12,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
+import coil.load
 import com.boolder.boolder.R
 import com.boolder.boolder.databinding.ViewProblemBinding
 import com.boolder.boolder.domain.model.CircuitColor
@@ -19,12 +20,7 @@ import com.boolder.boolder.domain.model.CompleteProblem
 import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.domain.model.Steepness
 import com.boolder.boolder.utils.CubicCurveAlgorithm
-import com.squareup.picasso.Callback
-import com.squareup.picasso.OkHttp3Downloader
-import com.squareup.picasso.Picasso
-import okhttp3.OkHttpClient
 import java.util.Locale
-import java.util.concurrent.TimeUnit.SECONDS
 
 class ProblemView(
     context: Context,
@@ -185,28 +181,21 @@ class ProblemView(
         binding.progressCircular.isVisible = true
 
         if (completeProblem.topo != null) {
-            val okHttpClient = OkHttpClient.Builder()
-                .connectTimeout(10, SECONDS)
-                .build()
+            binding.picture.load(completeProblem.topo.url) {
+                crossfade(true)
+                error(R.drawable.ic_placeholder)
 
-            Picasso.Builder(context)
-                .downloader(OkHttp3Downloader(okHttpClient))
-                .build()
-                .load(completeProblem.topo.url)
-                .error(R.drawable.ic_placeholder)
-                .into(binding.picture, object : Callback {
-                    override fun onSuccess() {
+                listener(
+                    onSuccess = { _, _ ->
                         context?.let {
                             binding.picture.setPadding(0)
                             binding.progressCircular.isVisible = false
                             onProblemPictureLoaded(completeProblem)
                         }
-                    }
-
-                    override fun onError(e: java.lang.Exception?) {
-                        loadErrorPicture()
-                    }
-                })
+                    },
+                    onError = { _, _ -> loadErrorPicture() }
+                )
+            }
         } else loadErrorPicture()
     }
 

--- a/app/src/main/java/com/boolder/boolder/view/detail/ProblemView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/ProblemView.kt
@@ -7,18 +7,15 @@ import android.net.Uri
 import android.util.AttributeSet
 import android.util.Log
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
-import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
 import com.boolder.boolder.R
 import com.boolder.boolder.databinding.ViewProblemBinding
 import com.boolder.boolder.domain.model.CircuitColor
 import com.boolder.boolder.domain.model.CompleteProblem
-import com.boolder.boolder.domain.model.Line
 import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.domain.model.Steepness
 import com.boolder.boolder.utils.CubicCurveAlgorithm
@@ -36,80 +33,64 @@ class ProblemView(
 
     private val binding = ViewProblemBinding.inflate(LayoutInflater.from(context), this)
 
-    private var completeProblem: CompleteProblem? = null
-
-    private var selectedProblem: Problem? = null
-    private var selectedLine: Line? = null
-
-    private val bleauUrl
-        get() = selectedProblem?.bleauInfoId?.let { "https://bleau.info/a/$it.html" }
-    private val shareUrl
-        get() = selectedProblem?.id?.let { "https://www.boolder.com/${Locale.getDefault().language}/p/$it" }
-
     init {
         setBackgroundColor(Color.WHITE)
+        isClickable = true
+        isFocusable = true
     }
 
-    fun setProblem(problem: CompleteProblem) {
-        completeProblem = problem
-        selectedLine = completeProblem?.line
-        selectedProblem = completeProblem?.problem
-
-        children.filterIsInstance<ProblemStartView>()
-            .forEach(::removeView)
-
+    fun setProblem(completeProblem: CompleteProblem) {
+        binding.problemStartsContainer.removeAllViews()
         binding.lineVector.clearPath()
 
-        hideBleauButton()
-        loadBoolderImage()
-        updateLabels()
-        setupChipClick()
+        loadBoolderImage(completeProblem)
+        updateLabels(completeProblem.problem)
+        setupChipClick(completeProblem.problem)
     }
 
-    private fun markParentAsSelected() {
-        selectedLine = completeProblem?.line
-        selectedProblem = completeProblem?.problem
-        drawCurves()
-        drawCircuitNumberCircle()
-        updateLabels()
+    private fun onProblemPictureLoaded(completeProblem: CompleteProblem) {
+        completeProblem.otherCompleteProblem.forEach(::drawCircuitNumberCircle)
+
+        drawCircuitNumberCircle(completeProblem)
+        drawCurves(completeProblem)
     }
 
-    private fun hideBleauButton() {
-        if (selectedProblem?.bleauInfoId.isNullOrEmpty()) {
-            binding.bleauInfo.visibility = View.GONE
-        }
+    private fun onProblemStartClicked(completeProblem: CompleteProblem) {
+        updateLabels(completeProblem.problem)
+        setupChipClick(completeProblem.problem)
+        drawCurves(completeProblem)
     }
 
     //region Draw
-    private fun drawCurves() {
-        val points = selectedLine?.points()
+    private fun drawCurves(completeProblem: CompleteProblem) {
+        binding.lineVector.clearPath()
 
-        if (!points.isNullOrEmpty()) {
-            val problemColor = selectedProblem?.getColor(context) ?: return
+        val points = completeProblem.line?.points()
 
-            val segment = CubicCurveAlgorithm().controlPointsFromPoints(points)
+        if (points.isNullOrEmpty()) return
 
-            val ctrl1 = segment.map { PointD(it.controlPoint1.x, it.controlPoint1.y) }
-            val ctrl2 = segment.map { PointD(it.controlPoint2.x, it.controlPoint2.y) }
+        val problemColor = completeProblem.problem.getColor(context)
 
-            binding.lineVector.apply {
-                addDataPoints(
-                    data = points,
-                    point1 = ctrl1,
-                    point2 = ctrl2,
-                    drawColor = problemColor
-                )
-                animatePath()
-            }
-        } else {
-            binding.lineVector.clearPath()
+        val segment = CubicCurveAlgorithm().controlPointsFromPoints(points)
+
+        val ctrl1 = segment.map { PointD(it.controlPoint1.x, it.controlPoint1.y) }
+        val ctrl2 = segment.map { PointD(it.controlPoint2.x, it.controlPoint2.y) }
+
+        binding.lineVector.apply {
+            addDataPoints(
+                data = points,
+                point1 = ctrl1,
+                point2 = ctrl2,
+                drawColor = problemColor
+            )
+            animatePath()
         }
     }
 
-    private fun drawCircuitNumberCircle() {
-        val pointD = selectedLine?.points()?.firstOrNull()
+    private fun drawCircuitNumberCircle(completeProblem: CompleteProblem) {
+        val pointD = completeProblem.line?.points()?.firstOrNull()
         if (pointD != null) {
-            val viewSizeRes = if (selectedProblem?.circuitNumber.isNullOrBlank()) {
+            val viewSizeRes = if (completeProblem.problem.circuitNumber.isNullOrBlank()) {
                 R.dimen.size_problem_start_without_number
             } else {
                 R.dimen.size_problem_start_with_number
@@ -120,33 +101,34 @@ class ProblemView(
             val viewWithMarginSize = viewSize + marginProblemStart * 2
             val offset = viewWithMarginSize / 2
 
-            val textColor = when (selectedProblem?.circuitColorSafe) {
+            val textColor = when (completeProblem.problem.circuitColorSafe) {
                 CircuitColor.WHITE -> Color.BLACK
                 else -> Color.WHITE
             }
 
             val problemStartView = ProblemStartView(binding.root.context).apply {
-                setText(selectedProblem?.circuitNumber)
+                setText(completeProblem.problem.circuitNumber)
                 setTextColor(textColor)
-                selectedProblem?.getColor(context)?.let(::setProblemColor)
+                setProblemColor(completeProblem.problem.getColor(context))
                 translationX = (pointD.x * binding.picture.measuredWidth - offset).toFloat()
                 translationY = (pointD.y * binding.picture.measuredHeight - offset).toFloat()
+
+                setOnClickListener { onProblemStartClicked(completeProblem) }
             }
 
-            addView(problemStartView, LayoutParams(WRAP_CONTENT, WRAP_CONTENT))
+            binding.problemStartsContainer.addView(problemStartView, LayoutParams(WRAP_CONTENT, WRAP_CONTENT))
         }
     }
     //endregion
 
-    private fun updateLabels() {
-        binding.title.text = selectedProblem?.nameSafe()
-        binding.grade.text = selectedProblem?.grade
+    private fun updateLabels(problem: Problem) {
+        binding.title.text = problem.nameSafe()
+        binding.grade.text = problem.grade
 
-        val steepness = selectedProblem?.steepness?.let(Steepness::fromTextValue)
+        val steepness = Steepness.fromTextValue(problem.steepness)
 
         binding.typeIcon.apply {
-            val steepnessDrawable = steepness
-                ?.iconRes
+            val steepnessDrawable = steepness.iconRes
                 ?.let { ContextCompat.getDrawable(context, it) }
 
             setImageDrawable(steepnessDrawable)
@@ -154,9 +136,9 @@ class ProblemView(
         }
 
         binding.typeText.apply {
-            val steepnessText = steepness?.textRes?.let(context::getString)
+            val steepnessText = steepness.textRes?.let(context::getString)
 
-            val sitStartText = if (selectedProblem?.sitStart == true) {
+            val sitStartText = if (problem.sitStart) {
                 resources.getString(R.string.sit_start)
             } else null
 
@@ -165,21 +147,25 @@ class ProblemView(
         }
     }
 
-    private fun setupChipClick() {
+    private fun setupChipClick(problem: Problem) {
+        binding.bleauInfo.isVisible = !problem.bleauInfoId.isNullOrEmpty()
         binding.bleauInfo.setOnClickListener {
             try {
+                val bleauUrl = "https://bleau.info/a/${problem.bleauInfoId}.html"
                 val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(bleauUrl))
                 context.startActivity(browserIntent)
             } catch (e: Exception) {
                 Log.i("Bottom Sheet", "No apps can handle this kind of intent")
             }
-
         }
 
         binding.share.setOnClickListener {
-            val sendIntent: Intent = Intent().apply {
+            val sendIntent = Intent().apply {
                 action = Intent.ACTION_SEND
-                putExtra(Intent.EXTRA_TEXT, shareUrl)
+                putExtra(
+                    Intent.EXTRA_TEXT,
+                    "https://www.boolder.com/${Locale.getDefault().language}/p/${problem.id}"
+                )
                 type = "text/plain"
             }
 
@@ -192,10 +178,10 @@ class ProblemView(
         }
     }
 
-    private fun loadBoolderImage() {
+    private fun loadBoolderImage(completeProblem: CompleteProblem) {
         binding.progressCircular.isVisible = true
 
-        if (completeProblem?.topo != null) {
+        if (completeProblem.topo != null) {
             val okHttpClient = OkHttpClient.Builder()
                 .connectTimeout(10, SECONDS)
                 .build()
@@ -203,14 +189,14 @@ class ProblemView(
             Picasso.Builder(context)
                 .downloader(OkHttp3Downloader(okHttpClient))
                 .build()
-                .load(completeProblem?.topo?.url)
+                .load(completeProblem.topo.url)
                 .error(R.drawable.ic_placeholder)
                 .into(binding.picture, object : Callback {
                     override fun onSuccess() {
                         context?.let {
                             binding.picture.setPadding(0)
                             binding.progressCircular.isVisible = false
-                            markParentAsSelected()
+                            onProblemPictureLoaded(completeProblem)
                         }
                     }
 

--- a/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
@@ -130,6 +130,10 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
             }
         }
 
+        binding.problemView.onProblemFromSameTopoSelected = { problemId ->
+            binding.mapView.selectProblem(problemId)
+        }
+
         mapViewModel.gradeStateFlow.launchAndCollectIn(owner = this) {
             binding.mapView.filterGrades(it.grades)
             binding.gradesFilterButton.text = it.gradeRangeButtonTitle
@@ -152,6 +156,11 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
 
             mapViewModel.onGradeRangeSelected(gradeRange)
         }
+    }
+
+    override fun onDestroy() {
+        binding.problemView.onProblemFromSameTopoSelected = null
+        super.onDestroy()
     }
 
     override fun onGPSLocation(location: Location) {

--- a/app/src/main/res/layout/view_problem.xml
+++ b/app/src/main/res/layout/view_problem.xml
@@ -35,6 +35,13 @@
         app:layout_constraintDimensionRatio="4:3"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <FrameLayout
+        android:id="@+id/problem_starts_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintDimensionRatio="4:3"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
         android:id="@+id/title"
         android:layout_width="0dp"


### PR DESCRIPTION
Some boulder pictures could display several problem starts, and make the user experience better by avoiding to reload the same picture.

https://github.com/boolder-org/boolder-android/assets/8343416/7b529dc2-0381-4afd-bcdb-ef4aa31c0621

This commit also ships two small fixes:
* fix a blinking point in some cases during the animation of the problem line
* avoid triggering a click on the map below the bottom sheet when it is expanded

Resolves #19 