### PR TITLE
Fix boulder problem line recomposition

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/detail/composable/ProblemLine.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/composable/ProblemLine.kt
@@ -53,7 +53,7 @@ internal fun ProblemLine(
         val width = constraints.maxWidth
         val height = constraints.maxHeight
 
-        LaunchedEffect(key1 = points) {
+        LaunchedEffect(key1 = points, key2 = color) {
             internalColor = Color.Transparent
             path.reset()
 

--- a/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import android.util.TypedValue
 import com.boolder.boolder.R
 import com.boolder.boolder.domain.model.BoolderMapConfig
-import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.utils.MapboxStyleFactory
 import com.boolder.boolder.view.map.animator.animationEndListener
 import com.mapbox.bindgen.Expected
@@ -171,7 +170,7 @@ class BoolderMap @JvmOverloads constructor(
                     selectProblem(feature.getNumberProperty("id").toString())
                     listener?.onProblemSelected(feature.getNumberProperty("id").toInt())
 
-                    // Move camera is problem is hidden by bottomSheet
+                    // Move camera if problem is hidden by bottomSheet
                     if (geometry.screenCoordinate.y >= (height / 2) - 100) {
 
                         val cameraOption = CameraOptions.Builder()
@@ -234,30 +233,6 @@ class BoolderMap @JvmOverloads constructor(
             unselectProblem()
         }
         previousSelectedFeatureId = featureId
-    }
-
-    fun selectProblemAndCenter(problem: Problem) {
-        selectProblem(problem.id.toString())
-        val point = Point.fromLngLat(
-            problem.longitude.toDouble(),
-            problem.latitude.toDouble()
-        )
-
-        val coordinates = getMapboxMap().pixelForCoordinate(point)
-
-        // Move camera is problem is hidden by bottomSheet
-        if (coordinates.y >= height / 2) {
-
-            val cameraOption = CameraOptions.Builder()
-                .center(point)
-                .padding(EdgeInsets(40.0, 8.8, (height / 2).toDouble(), 8.8))
-                .build()
-            val mapAnimationOption = MapAnimationOptions.Builder()
-                .duration(500L)
-                .build()
-
-            getMapboxMap().easeTo(cameraOption, mapAnimationOption)
-        }
     }
 
     private fun unselectProblem() {

--- a/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
@@ -257,14 +257,19 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
     private fun flyToProblem(problem: Problem) {
         onProblemSelected(problem.id)
         binding.mapView.selectProblem(problem.id.toString())
+
         val point = Point.fromLngLat(
             problem.longitude.toDouble(),
             problem.latitude.toDouble()
         )
 
-        val cameraOptions = CameraOptions.Builder().center(point).zoom(20.0).build()
+        val cameraOptions = CameraOptions.Builder()
+            .center(point)
+            .padding(EdgeInsets(40.0, 0.0, (binding.mapView.height / 2).toDouble(), 0.0))
+            .zoom(20.0)
+            .build()
 
-        binding.mapView.camera.flyTo(
+        binding.mapView.camera.easeTo(
             cameraOptions = cameraOptions,
             animationOptions = defaultMapAnimationOptions {
                 animatorListener(animationEndListener { onAreaVisited(problem.areaId) })


### PR DESCRIPTION
The boulder problem line was not redrawn in case the line coordinates were the same as the previously displayed one. In order to redraw the line, the line color has been added as a key, in addition to the line coordinates, so that the launched effect that animates the line will be triggered.

https://github.com/boolder-org/boolder-android/assets/8343416/75dc1ebe-2a4d-420b-9f63-4117fb33b86c

In addition, the selecting a boulder problem from the search will also center it on the map (before, it was covered by the bottom sheet).

Resolves #43 