### PR TITLE
Fix topo bottom sheet state when flying to an area

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
@@ -130,12 +130,12 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
             }
         }
 
-        binding.problemView.onSelectProblemOnMap = { problemId ->
+        binding.topoView.onSelectProblemOnMap = { problemId ->
             binding.mapView.selectProblem(problemId)
         }
 
         mapViewModel.topoStateFlow.launchAndCollectIn(owner = this) { topo ->
-            topo?.let(binding.problemView::setTopo)
+            topo?.let(binding.topoView::setTopo)
             bottomSheetBehavior.state = if (topo == null) STATE_HIDDEN else STATE_EXPANDED
         }
 
@@ -164,7 +164,7 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
     }
 
     override fun onDestroy() {
-        binding.problemView.onSelectProblemOnMap = null
+        binding.topoView.onSelectProblemOnMap = null
         super.onDestroy()
     }
 
@@ -252,6 +252,8 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
                 animatorListener(animationEndListener { onAreaVisited(area.id) })
             }
         )
+
+        bottomSheetBehavior.state = STATE_HIDDEN
     }
 
     private fun flyToProblem(problem: Problem) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -68,7 +68,7 @@
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
         <com.boolder.boolder.view.detail.TopoView
-            android:id="@+id/problem_view"
+            android:id="@+id/topo_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 


### PR DESCRIPTION
Avoid displaying the previous boulder problem when flying to an area.

https://github.com/boolder-org/boolder-android/assets/8343416/dcd7089d-3ac9-4525-aecd-afcf0f6b6739

Resolves #42 