### PR TITLE
Fix circuit controls when problem has no photo

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/map/TopoDataAggregator.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/TopoDataAggregator.kt
@@ -21,22 +21,27 @@ class TopoDataAggregator(
     suspend fun aggregate(problemId: Int, origin: TopoOrigin): Topo {
         val mainProblem: ProblemEntity = problemRepository.loadById(problemId) ?: return EMPTY_TOPO
 
-        val mainLine = lineRepository.loadByProblemId(problemId) ?: return EMPTY_TOPO
+        val mainLine = lineRepository.loadByProblemId(problemId)
 
-        val topoId = mainLine.topoId
-        val topoPictureUrl = topoRepository.getTopoPictureById(topoId)
+        val topoId = mainLine?.topoId
+
+        val topoPictureUrl = topoId?.let { topoRepository.getTopoPictureById(it) }
 
         val mainProblemAndLine = ProblemWithLine(
             problem = mainProblem.convert(),
-            line = mainLine.convert()
+            line = mainLine?.convert()
         )
 
         val mainCompleteProblem = getCompleteProblem(mainProblemAndLine)
 
-        val otherCompleteProblems = getOtherCompleteProblemsFromTopo(
-            topoId = topoId,
-            mainProblemWithLine = mainProblemAndLine
-        )
+        val otherCompleteProblems = topoId
+            ?.let {
+                getOtherCompleteProblemsFromTopo(
+                    topoId = topoId,
+                    mainProblemWithLine = mainProblemAndLine
+                )
+            }
+            ?: emptyList()
 
         val (circuitPreviousProblemId, circuitNextProblemId) = getCircuitPreviousAndNextProblemIds(mainProblem)
 


### PR DESCRIPTION
The circuit controls were not displayed when a boulder problem had no photo. This commit fixes this behavior.

https://github.com/boolder-org/boolder-android/assets/8343416/8904c6c1-47a5-456f-a7c2-87ee3c7d5f46

Resolves #51 