### PR TITLE
Fix variants button disparition

### DIFF
--- a/app/src/main/java/com/boolder/boolder/domain/model/CompleteProblem.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/model/CompleteProblem.kt
@@ -2,6 +2,7 @@ package com.boolder.boolder.domain.model
 
 import androidx.annotation.Px
 import com.boolder.boolder.view.detail.uimodel.ProblemStart
+import com.boolder.boolder.view.detail.uimodel.UiProblem
 import kotlin.math.roundToInt
 
 /**
@@ -12,7 +13,18 @@ data class CompleteProblem(
     val variants: List<ProblemWithLine>
 )
 
-fun CompleteProblem.toProblemStart(
+fun CompleteProblem.toUiProblem(
+    @Px containerWidthPx: Int,
+    @Px containerHeightPx: Int
+) = UiProblem(
+    completeProblem = this,
+    problemStart = toProblemStart(
+        containerWidthPx = containerWidthPx,
+        containerHeightPx = containerHeightPx
+    )
+)
+
+private fun CompleteProblem.toProblemStart(
     @Px containerWidthPx: Int,
     @Px containerHeightPx: Int
 ): ProblemStart? {
@@ -29,7 +41,6 @@ fun CompleteProblem.toProblemStart(
             android.R.color.black
         } else {
             android.R.color.white
-        },
-        completeProblem = this
+        }
     )
 }

--- a/app/src/main/java/com/boolder/boolder/utils/previewgenerator/ProblemStartGenerator.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/previewgenerator/ProblemStartGenerator.kt
@@ -1,18 +1,15 @@
 package com.boolder.boolder.utils.previewgenerator
 
 import com.boolder.boolder.domain.model.CircuitColor
-import com.boolder.boolder.domain.model.CompleteProblem
 import com.boolder.boolder.view.detail.uimodel.ProblemStart
 
 fun dummyProblemStart(
     x: Int,
-    y: Int,
-    completeProblem: CompleteProblem = dummyCompleteProblem()
+    y: Int
 ) = ProblemStart(
     x = x,
     y = y,
     dpSize = 28,
     colorRes = CircuitColor.RED.colorRes,
-    textColorRes = android.R.color.white,
-    completeProblem = completeProblem
+    textColorRes = android.R.color.white
 )

--- a/app/src/main/java/com/boolder/boolder/view/detail/TopoView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/TopoView.kt
@@ -22,11 +22,11 @@ import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.domain.model.ProblemWithLine
 import com.boolder.boolder.domain.model.Steepness
 import com.boolder.boolder.domain.model.Topo
-import com.boolder.boolder.domain.model.toProblemStart
+import com.boolder.boolder.domain.model.toUiProblem
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.detail.composable.CircuitControls
 import com.boolder.boolder.view.detail.composable.ProblemStartsLayer
-import com.boolder.boolder.view.detail.uimodel.ProblemStart
+import com.boolder.boolder.view.detail.uimodel.UiProblem
 import java.util.Locale
 
 class TopoView(
@@ -36,14 +36,14 @@ class TopoView(
 
     private val binding = ViewTopoBinding.inflate(LayoutInflater.from(context), this)
 
-    private var problemStarts: List<ProblemStart> = emptyList()
+    private var uiProblems: List<UiProblem> = emptyList()
 
     var onSelectProblemOnMap: ((problemId: String) -> Unit)? = null
     var onCircuitProblemSelected: ((problemId: Int) -> Unit)? = null
 
     fun setTopo(topo: Topo) {
-        setProblemStarts(
-            problemStarts = emptyList(),
+        setUiProblems(
+            uiProblems = emptyList(),
             selectedProblem = null
         )
 
@@ -63,24 +63,22 @@ class TopoView(
         val containerWidth = binding.picture.measuredWidth
         val containerHeight = binding.picture.measuredHeight
 
-        val initialProblemStart = selectedProblem.toProblemStart(
+        val initialUiProblem = selectedProblem.toUiProblem(
             containerWidthPx = containerWidth,
             containerHeightPx = containerHeight
         )
 
-        val otherProblemStarts = topo.otherCompleteProblems.mapNotNull {
-            it.toProblemStart(
+        val otherUiProblems = topo.otherCompleteProblems.map {
+            it.toUiProblem(
                 containerWidthPx = containerWidth,
                 containerHeightPx = containerHeight
             )
         }
 
-        this.problemStarts = initialProblemStart
-            ?.let { otherProblemStarts + it }
-            ?: otherProblemStarts
+        this.uiProblems = otherUiProblems + initialUiProblem
 
-        setProblemStarts(
-            problemStarts = problemStarts,
+        setUiProblems(
+            uiProblems = uiProblems,
             selectedProblem = selectedProblem
         )
     }
@@ -90,30 +88,30 @@ class TopoView(
 
         updateLabels(problem)
         setupChipClick(problem)
-        setProblemStarts(
-            problemStarts = problemStarts,
+        setUiProblems(
+            uiProblems = uiProblems,
             selectedProblem = completeProblem
         )
         onSelectProblemOnMap?.invoke(problem.id.toString())
     }
 
     private fun onVariantSelected(variant: ProblemWithLine) {
-        val (selectedProblem, newProblemStarts) = VariantSelector.selectVariantInProblemStarts(
+        val (selectedProblem, newUiProblems) = VariantSelector.selectVariantInProblemStarts(
             selectedVariant = variant,
-            problemStarts = problemStarts,
+            uiProblems = uiProblems,
             containerWidth = binding.picture.measuredWidth,
             containerHeight = binding.picture.measuredHeight
         )
 
-        problemStarts = newProblemStarts
+        uiProblems = newUiProblems
 
         selectedProblem?.let {
             updateLabels(it.problemWithLine.problem)
             setupChipClick(it.problemWithLine.problem)
         }
 
-        setProblemStarts(
-            problemStarts = problemStarts,
+        setUiProblems(
+            uiProblems = uiProblems,
             selectedProblem = selectedProblem
         )
 
@@ -230,8 +228,8 @@ class TopoView(
         binding.progressCircular.isVisible = false
     }
 
-    private fun setProblemStarts(
-        problemStarts: List<ProblemStart>,
+    private fun setUiProblems(
+        uiProblems: List<UiProblem>,
         selectedProblem: CompleteProblem?
     ) {
         binding.problemStartsComposeView.setContent {
@@ -240,7 +238,7 @@ class TopoView(
                     modifier = Modifier
                         .fillMaxWidth()
                         .aspectRatio(4f / 3f),
-                    problemStarts = problemStarts,
+                    uiProblems = uiProblems,
                     selectedProblem = selectedProblem,
                     onProblemStartClicked = ::onProblemStartClicked,
                     onVariantSelected = ::onVariantSelected

--- a/app/src/main/java/com/boolder/boolder/view/detail/VariantSelector.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/VariantSelector.kt
@@ -3,20 +3,20 @@ package com.boolder.boolder.view.detail
 import androidx.annotation.Px
 import com.boolder.boolder.domain.model.CompleteProblem
 import com.boolder.boolder.domain.model.ProblemWithLine
-import com.boolder.boolder.domain.model.toProblemStart
-import com.boolder.boolder.view.detail.uimodel.ProblemStart
+import com.boolder.boolder.domain.model.toUiProblem
+import com.boolder.boolder.view.detail.uimodel.UiProblem
 
 object VariantSelector {
 
     fun selectVariantInProblemStarts(
         selectedVariant: ProblemWithLine,
-        problemStarts: List<ProblemStart>,
+        uiProblems: List<UiProblem>,
         @Px containerWidth: Int,
         @Px containerHeight: Int
-    ): Pair<CompleteProblem?, List<ProblemStart>> {
+    ): Pair<CompleteProblem?, List<UiProblem>> {
         var selectedProblem: CompleteProblem? = null
 
-        val newProblemStarts = problemStarts.mapNotNull { problemStart ->
+        val newProblemStarts = uiProblems.mapNotNull { problemStart ->
             val completeProblem = problemStart.completeProblem
 
             if (completeProblem.problemWithLine == selectedVariant) {
@@ -25,7 +25,7 @@ object VariantSelector {
                     selectedVariant = selectedVariant
                 )
                     .also { selectedProblem = it }
-                    .toProblemStart(
+                    .toUiProblem(
                         containerWidthPx = containerWidth,
                         containerHeightPx = containerHeight
                     )
@@ -37,7 +37,7 @@ object VariantSelector {
                     selectedVariant = selectedVariant
                 )
                     .also { selectedProblem = it }
-                    .toProblemStart(
+                    .toUiProblem(
                         containerWidthPx = containerWidth,
                         containerHeightPx = containerHeight
                     )

--- a/app/src/main/java/com/boolder/boolder/view/detail/composable/ProblemStartsLayer.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/composable/ProblemStartsLayer.kt
@@ -32,32 +32,35 @@ import com.boolder.boolder.utils.previewgenerator.dummyCompleteProblem
 import com.boolder.boolder.utils.previewgenerator.dummyProblemStart
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.detail.uimodel.ProblemStart
+import com.boolder.boolder.view.detail.uimodel.UiProblem
 import kotlin.math.roundToInt
 
 @Composable
 internal fun ProblemStartsLayer(
-    problemStarts: List<ProblemStart>,
+    uiProblems: List<UiProblem>,
     selectedProblem: CompleteProblem?,
     onProblemStartClicked: (CompleteProblem) -> Unit,
     onVariantSelected: (ProblemWithLine) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier) {
-        problemStarts.forEach { problemStart ->
-            val shadowRadius = 2.dp
+        uiProblems.forEach { uiProblem ->
+            uiProblem.problemStart?.let { problemStart ->
+                val shadowRadius = 2.dp
 
-            MarkerShadow(
-                problemStart = problemStart,
-                shadowRadius = shadowRadius
-            )
-
-            if (problemStart.completeProblem.problemWithLine.problem.id != selectedProblem?.problemWithLine?.problem?.id) {
-                ProblemStartMarker(
+                MarkerShadow(
                     problemStart = problemStart,
-                    modifier = Modifier.clickable {
-                        onProblemStartClicked(problemStart.completeProblem)
-                    }
+                    shadowRadius = shadowRadius
                 )
+
+                if (uiProblem.completeProblem.problemWithLine.problem.id != selectedProblem?.problemWithLine?.problem?.id) {
+                    ProblemStartMarker(
+                        uiProblem = uiProblem,
+                        modifier = Modifier.clickable {
+                            onProblemStartClicked(uiProblem.completeProblem)
+                        }
+                    )
+                }
             }
         }
 
@@ -67,11 +70,11 @@ internal fun ProblemStartsLayer(
                 color = selectedProblem.problemWithLine.problem.circuitColorSafe.composeColor()
             )
 
-            problemStarts
+            uiProblems
                 .find { it.completeProblem.problemWithLine.problem.id == selectedProblem.problemWithLine.problem.id }
                 ?.let {
                     ProblemStartMarker(
-                        problemStart = it,
+                        uiProblem = it,
                         modifier = Modifier
                     )
                 }
@@ -87,9 +90,11 @@ internal fun ProblemStartsLayer(
 
 @Composable
 private fun ProblemStartMarker(
-    problemStart: ProblemStart,
+    uiProblem: UiProblem,
     modifier: Modifier
 ) {
+    val problemStart = uiProblem.problemStart ?: return
+
     val markerHalfSizePx = with(LocalDensity.current) {
         (problemStart.dpSize.dp / 2).toPx().roundToInt()
     }
@@ -112,7 +117,7 @@ private fun ProblemStartMarker(
     ) {
         Text(
             modifier = Modifier.align(Alignment.Center),
-            text = problemStart.completeProblem.problemWithLine.problem.circuitNumber.orEmpty(),
+            text = uiProblem.completeProblem.problemWithLine.problem.circuitNumber.orEmpty(),
             color = colorResource(id = problemStart.textColorRes),
             fontSize = 18.sp
         )
@@ -167,10 +172,13 @@ internal fun ProblemStartsLayerPreview() {
                     .fillMaxWidth()
                     .aspectRatio(4f / 3f)
                     .background(color = Color.White),
-                problemStarts = listOf(
-                    dummyProblemStart(
-                        x = (0.76 * constraints.maxWidth).roundToInt(),
-                        y = (0.7533 * constraints.maxHeight).roundToInt()
+                uiProblems = listOf(
+                    UiProblem(
+                        completeProblem,
+                        dummyProblemStart(
+                            x = (0.76 * constraints.maxWidth).roundToInt(),
+                            y = (0.7533 * constraints.maxHeight).roundToInt()
+                        )
                     )
                 ),
                 selectedProblem = completeProblem,

--- a/app/src/main/java/com/boolder/boolder/view/detail/uimodel/ProblemStart.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/uimodel/ProblemStart.kt
@@ -1,13 +1,23 @@
 package com.boolder.boolder.view.detail.uimodel
 
 import androidx.annotation.ColorRes
-import com.boolder.boolder.domain.model.CompleteProblem
 
+/**
+ * Container for the data that is only needed in the UI, in order to render the
+ * starting points of the boulder problems.
+ *
+ * @param x the horizontal coordinate on the photo, in pixels
+ * @param y the vertical coordinate on the photo, in pixels
+ * @param dpSize the size of the boulder problem start marker, in dp
+ * @param colorRes the resource identifying the color of the boulder problem
+ * start marker
+ * @param textColorRes the resource identifying the text color of the boulder
+ * problem start marker
+ */
 data class ProblemStart(
     val x: Int,
     val y: Int,
     val dpSize: Int,
     @ColorRes val colorRes: Int,
-    @ColorRes val textColorRes: Int,
-    val completeProblem: CompleteProblem
+    @ColorRes val textColorRes: Int
 )

--- a/app/src/main/java/com/boolder/boolder/view/detail/uimodel/TopoUiProblem.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/uimodel/TopoUiProblem.kt
@@ -1,0 +1,16 @@
+package com.boolder.boolder.view.detail.uimodel
+
+import com.boolder.boolder.domain.model.CompleteProblem
+
+/**
+ * Container for a [CompleteProblem] and its associated UI data to render a
+ * boulder problem start marker.
+ *
+ * @param completeProblem the boulder problem with its variants
+ * @param problemStart the associated UI data to render a boulder problem start
+ * marker
+ */
+data class UiProblem(
+    val completeProblem: CompleteProblem,
+    val problemStart: ProblemStart?
+)


### PR DESCRIPTION
The variants button was disappearing when the displayed boulder problem did not have any starting point rendered over the photo. This is now fixed by changing the models' structure.

https://github.com/boolder-org/boolder-android/assets/8343416/06d3ceb6-e6e7-4f72-a799-c781f9a580f5

Resolves #50 