### PR TITLE
Fix quick navigation between problems of the same circuit

### DIFF
--- a/app/src/main/java/com/boolder/boolder/domain/model/Steepness.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/model/Steepness.kt
@@ -5,8 +5,8 @@ import androidx.annotation.StringRes
 import com.boolder.boolder.R
 
 enum class Steepness(
-    @StringRes val textRes: Int?,
-    @DrawableRes val iconRes: Int?
+    @StringRes val textRes: Int,
+    @DrawableRes val iconRes: Int
 ) {
     SLAB(
         textRes = R.string.stepness_slab,
@@ -27,20 +27,16 @@ enum class Steepness(
     TRAVERSE(
         textRes = R.string.stepness_traverse,
         iconRes = R.drawable.ic_steepness_traverse_left_right
-    ),
-    OTHER(
-        textRes = null,
-        iconRes = null
     );
 
     companion object {
-        fun fromTextValue(value: String): Steepness = when (value.lowercase()) {
+        fun fromTextValue(value: String): Steepness? = when (value.lowercase()) {
             "slab" -> SLAB
             "overhang" -> OVERHANG
             "roof" -> ROOF
             "wall" -> WALL
             "traverse" -> TRAVERSE
-            else -> OTHER
+            else -> null
         }
     }
 }

--- a/app/src/main/java/com/boolder/boolder/utils/previewgenerator/ProblemGenerator.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/previewgenerator/ProblemGenerator.kt
@@ -1,0 +1,25 @@
+package com.boolder.boolder.utils.previewgenerator
+
+import com.boolder.boolder.domain.model.Problem
+
+fun dummyProblem(
+    id: Int = 1000,
+    name: String = "The dummy problem"
+) = Problem(
+    id = id,
+    name = name,
+    nameEn = name,
+    grade = "5b",
+    latitude = 0f,
+    longitude = 0f,
+    circuitId = null,
+    circuitNumber = "10",
+    circuitColor = "RED",
+    steepness = "wall",
+    sitStart = true,
+    areaId = 1000,
+    bleauInfoId = null,
+    featured = false,
+    parentId = null,
+    areaName = null
+)

--- a/app/src/main/java/com/boolder/boolder/utils/previewgenerator/ProblemWithLineGenerator.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/previewgenerator/ProblemWithLineGenerator.kt
@@ -1,29 +1,11 @@
 package com.boolder.boolder.utils.previewgenerator
 
-import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.domain.model.ProblemWithLine
 
 fun dummyProblemWithLine(
     id: Int = 1000,
     name: String = "The dummy problem"
 ) = ProblemWithLine(
-    problem = Problem(
-        id = id,
-        name = name,
-        nameEn = name,
-        grade = "5b",
-        latitude = 0f,
-        longitude = 0f,
-        circuitId = null,
-        circuitNumber = "10",
-        circuitColor = "RED",
-        steepness = "",
-        sitStart = false,
-        areaId = 1000,
-        bleauInfoId = null,
-        featured = false,
-        parentId = null,
-        areaName = null
-    ),
+    problem = dummyProblem(id = id, name = name),
     line = dummyLine()
 )

--- a/app/src/main/java/com/boolder/boolder/view/detail/composable/TopoFooter.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/composable/TopoFooter.kt
@@ -1,0 +1,200 @@
+package com.boolder.boolder.view.detail.composable
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.ChipBorder
+import androidx.compose.material3.ChipColors
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.boolder.boolder.R
+import com.boolder.boolder.domain.model.Problem
+import com.boolder.boolder.domain.model.Steepness
+import com.boolder.boolder.utils.previewgenerator.dummyProblem
+import com.boolder.boolder.view.compose.BoolderTheme
+import java.util.Locale
+
+@Composable
+fun TopoFooter(
+    problem: Problem,
+    onBleauInfoClicked: (bleauInfoId: String?) -> Unit,
+    onShareClicked: (problemId: Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .height(140.dp)
+            .padding(8.dp),
+        verticalArrangement = spacedBy(8.dp)
+    ) {
+        TopoFooterTitleRow(
+            problemName = if (Locale.getDefault().language == "fr") {
+                problem.name.orEmpty()
+            } else {
+                problem.nameEn.orEmpty()
+            },
+            grade = problem.grade.orEmpty()
+        )
+
+        Steepness.fromTextValue(problem.steepness)?.let {
+            TopoProblemSteepness(
+                steepness = it,
+                isSitStart = problem.sitStart
+            )
+        }
+
+        ChipsRow(
+            onBleauInfoClicked = { onBleauInfoClicked(problem.bleauInfoId) },
+            onShareClicked = { onShareClicked(problem.id) }
+        )
+    }
+}
+
+@Composable
+private fun TopoFooterTitleRow(
+    problemName: String,
+    grade: String
+) {
+    Row {
+        Text(
+            modifier = Modifier.weight(1f),
+            text = problemName,
+            fontSize = 26.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Text(
+            text = grade,
+            fontSize = 26.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+private fun TopoProblemSteepness(
+    steepness: Steepness,
+    isSitStart: Boolean
+) {
+    Row(
+        horizontalArrangement = spacedBy(8.dp)
+    ) {
+        Icon(
+            modifier = Modifier.size(24.dp),
+            painter = painterResource(id = steepness.iconRes),
+            contentDescription = null
+        )
+
+        val steepnessText = stringResource(id = steepness.textRes)
+        val text = if (isSitStart) {
+            listOf(steepnessText, stringResource(id = R.string.sit_start))
+                .joinToString(separator = " • ")
+        } else {
+            steepnessText
+        }
+
+        Text(
+            text = text,
+            fontSize = 18.sp
+        )
+    }
+}
+
+@Composable
+private fun ChipsRow(
+    onBleauInfoClicked: () -> Unit,
+    onShareClicked: () -> Unit
+) {
+    Row(
+        horizontalArrangement = spacedBy(8.dp)
+    ) {
+        val colorPrimary = colorResource(id = R.color.primary)
+
+        ChipButton(
+            labelRes = R.string.bleau_info,
+            iconRes = R.drawable.ic_outline_info,
+            colors = AssistChipDefaults.assistChipColors(
+                containerColor = colorPrimary,
+                labelColor = Color.White,
+                leadingIconContentColor = Color.White
+            ),
+            border = AssistChipDefaults.assistChipBorder(borderWidth = 0.dp),
+            onClick = { onBleauInfoClicked() }
+        )
+
+        ChipButton(
+            labelRes = R.string.share,
+            iconRes = R.drawable.ic_share,
+            colors = AssistChipDefaults.assistChipColors(
+                containerColor = Color.Transparent,
+                labelColor = colorPrimary,
+                leadingIconContentColor = colorPrimary
+            ),
+            border = AssistChipDefaults.assistChipBorder(borderColor = colorPrimary),
+            onClick = onShareClicked
+        )
+    }
+}
+
+@Composable
+private fun ChipButton(
+    @StringRes labelRes: Int,
+    @DrawableRes iconRes: Int,
+    colors: ChipColors,
+    border: ChipBorder,
+    onClick: () -> Unit
+) {
+    AssistChip(
+        label = {
+            Text(
+                text = stringResource(id = labelRes),
+                fontSize = 18.sp
+            )
+        },
+        leadingIcon = {
+            Icon(
+                painter = painterResource(id = iconRes),
+                contentDescription = null
+            )
+        },
+        shape = CircleShape,
+        colors = colors,
+        border = border,
+        onClick = onClick
+    )
+}
+
+@Preview
+@Composable
+fun TopoFooterPreview() {
+    BoolderTheme {
+        TopoFooter(
+            modifier = Modifier.background(color = Color.White),
+            problem = dummyProblem(),
+            onBleauInfoClicked = {},
+            onShareClicked = {}
+        )
+    }
+}

--- a/app/src/main/res/layout/view_topo.xml
+++ b/app/src/main/res/layout/view_topo.xml
@@ -54,123 +54,13 @@
         app:layout_constraintStart_toStartOf="@+id/picture"
         app:layout_constraintTop_toTopOf="@+id/picture" />
 
-    <TextView
-        android:id="@+id/title"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/footer_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:ellipsize="end"
-        android:textColor="@color/black"
-        android:textSize="26sp"
-        android:textStyle="bold"
-        app:layout_constraintEnd_toStartOf="@+id/grade"
-        app:layout_constraintHorizontal_bias="1"
-        app:layout_constraintHorizontal_chainStyle="spread"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/picture"
-        tools:text="Le fer à Repasser" />
-
-    <TextView
-        android:id="@+id/grade"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="10dp"
-        android:textColor="@color/black"
-        android:textSize="26sp"
-        android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/title"
-        app:layout_constraintTop_toBottomOf="@+id/picture"
-        tools:text="5a" />
-
-    <ImageView
-        android:id="@+id/type_icon"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_margin="8dp"
-        android:contentDescription="@string/cd_type"
-        app:layout_constraintBottom_toBottomOf="@+id/type_text"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/type_text"
-        app:tint="@color/black"
-        tools:src="@drawable/ic_steepness_overhang" />
-
-    <TextView
-        android:id="@+id/type_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:textColor="@color/black"
-        android:textSize="18sp"
-        app:layout_constraintStart_toEndOf="@+id/type_icon"
-        app:layout_constraintTop_toBottomOf="@+id/title"
-        tools:text="Wall" />
-
-    <com.google.android.material.chip.Chip
-        android:id="@+id/bleau_info"
-        style="@style/Widget.MaterialComponents.Chip.Action"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginVertical="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginBottom="4dp"
-        android:text="@string/bleau_info"
-        android:textColor="@color/white"
-        android:textSize="18sp"
-        app:chipBackgroundColor="@color/primary"
-        app:chipEndPadding="8dp"
-        app:chipIcon="@drawable/ic_outline_info"
-        app:chipIconTint="@color/white"
-        app:chipMinHeight="36dp"
-        app:chipStartPadding="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/save"
-        app:layout_constraintHorizontal_bias="0"
-        app:layout_constraintHorizontal_chainStyle="packed"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/type_text" />
-
-    <com.google.android.material.chip.Chip
-        android:id="@+id/save"
-        style="@style/Widget.MaterialComponents.Chip.Action"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginVertical="8dp"
-        android:layout_marginStart="8dp"
-        android:text="@string/save"
-        android:textColor="@color/primary"
-        android:visibility="gone"
-        app:chipBackgroundColor="@color/white"
-        app:chipEndPadding="8dp"
-        app:chipIcon="@drawable/ic_outline_bookmark"
-        app:chipIconTint="@color/primary"
-        app:chipStartPadding="8dp"
-        app:chipStrokeColor="@color/primary"
-        app:chipStrokeWidth="1dp"
-        app:layout_constraintEnd_toStartOf="@id/share"
-        app:layout_constraintStart_toEndOf="@id/bleau_info"
-        app:layout_constraintTop_toBottomOf="@id/type_text" />
-
-    <com.google.android.material.chip.Chip
-        android:id="@+id/share"
-        style="@style/Widget.MaterialComponents.Chip.Action"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginVertical="8dp"
-        android:layout_marginStart="8dp"
-        android:text="@string/share"
-        android:textColor="@color/primary"
-        android:textSize="18sp"
-        app:chipBackgroundColor="@color/white"
-        app:chipEndPadding="8dp"
-        app:chipIcon="@drawable/ic_share"
-        app:chipIconTint="@color/primary"
-        app:chipMinHeight="36dp"
-        app:chipStartPadding="8dp"
-        app:chipStrokeColor="@color/primary"
-        app:chipStrokeWidth="1dp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/save"
-        app:layout_constraintTop_toBottomOf="@id/type_text" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/picture" />
 
 </merge>


### PR DESCRIPTION
When quickly navigating through the problems of a given circuit, the topo bottom sheet was sometimes dismissed due to the change of its height. To fix this, the footer of the topo has been set to a fixed height, so that it keeps the same size even if the topo has no steepness to display.

The footer has also been rewritten in compose to make the UI easier to maintain.

https://github.com/boolder-org/boolder-android/assets/8343416/f69498f6-75a5-48ef-8fad-0341738e1eab

