### PR TITLE
Fix circuit filter zoom when over a large area

### DIFF
--- a/app/src/main/java/com/boolder/boolder/utils/extension/CameraOptionsExtensions.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/extension/CameraOptionsExtensions.kt
@@ -1,0 +1,15 @@
+package com.boolder.boolder.utils.extension
+
+import com.mapbox.maps.CameraOptions
+
+fun CameraOptions.coerceZoomAtLeast(minZoom: Double): CameraOptions {
+    val zoom = zoom ?: return this
+
+    return CameraOptions.Builder()
+        .center(center)
+        .padding(padding)
+        .bearing(bearing)
+        .pitch(pitch)
+        .zoom(zoom.coerceAtLeast(minZoom))
+        .build()
+}

--- a/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
@@ -10,11 +10,12 @@ import com.boolder.boolder.R
 import com.boolder.boolder.domain.model.BoolderMapConfig
 import com.boolder.boolder.domain.model.Circuit
 import com.boolder.boolder.domain.model.TopoOrigin
-import com.boolder.boolder.utils.MapboxStyleFactory
 import com.boolder.boolder.utils.MapboxStyleFactory.Companion.LAYER_CIRCUITS
 import com.boolder.boolder.utils.MapboxStyleFactory.Companion.LAYER_CIRCUIT_PROBLEMS
 import com.boolder.boolder.utils.MapboxStyleFactory.Companion.LAYER_CIRCUIT_PROBLEMS_TEXT
 import com.boolder.boolder.utils.MapboxStyleFactory.Companion.LAYER_PROBLEMS
+import com.boolder.boolder.utils.MapboxStyleFactory.Companion.LAYER_PROBLEMS_TEXT
+import com.boolder.boolder.utils.extension.coerceZoomAtLeast
 import com.boolder.boolder.view.map.animator.animationEndListener
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.Value
@@ -356,7 +357,7 @@ class BoolderMap @JvmOverloads constructor(
         coordinates: CoordinateBounds,
         areaId: Int?
     ) {
-        val cameraOption = getMapboxMap().cameraForCoordinateBounds(
+        val cameraOptions = getMapboxMap().cameraForCoordinateBounds(
             coordinates,
             EdgeInsets(60.0, 8.0, 8.0, 8.0),
             0.0,
@@ -371,12 +372,12 @@ class BoolderMap @JvmOverloads constructor(
             animatorListener(animationEndListener { listener?.onAreaVisited(areaId) })
         }
 
-        getMapboxMap().flyTo(cameraOption, mapAnimationOption)
+        getMapboxMap().flyTo(cameraOptions, mapAnimationOption)
     }
 
     private fun zoomToCircuitBounds(circuitCoordinates: CoordinateBounds) {
         val defaultMarginPixels = 24.0 * resources.displayMetrics.density
-        val cameraOption = getMapboxMap().cameraForCoordinateBounds(
+        val cameraOptions = getMapboxMap().cameraForCoordinateBounds(
             circuitCoordinates,
             EdgeInsets(
                 140.0 * resources.displayMetrics.density + insets.top,
@@ -386,18 +387,18 @@ class BoolderMap @JvmOverloads constructor(
             ),
             0.0,
             0.0
-        )
+        ).coerceZoomAtLeast(15.0)
 
         val mapAnimationOption = MapAnimationOptions.mapAnimationOptions {
             duration(500L)
         }
 
-        getMapboxMap().flyTo(cameraOption, mapAnimationOption)
+        getMapboxMap().flyTo(cameraOptions, mapAnimationOption)
     }
 
 
     private fun zoomToBoulderProblemLevel(feature: Feature) {
-        val cameraOption = CameraOptions.Builder()
+        val cameraOptions = CameraOptions.Builder()
             .center(feature.geometry() as Point)
             .padding(EdgeInsets(0.0, 0.0,0.0, 0.0))
             .zoom(19.0)
@@ -405,18 +406,18 @@ class BoolderMap @JvmOverloads constructor(
 
         val mapAnimationOption = MapAnimationOptions.mapAnimationOptions { duration(500L) }
 
-        getMapboxMap().easeTo(cameraOption, mapAnimationOption)
+        getMapboxMap().easeTo(cameraOptions, mapAnimationOption)
     }
 
     private fun focusOnBoulderProblem(feature: Feature) {
-        val cameraOption = CameraOptions.Builder()
+        val cameraOptions = CameraOptions.Builder()
             .center(feature.geometry() as Point)
             .padding(EdgeInsets(40.0, 8.8, (height / 2).toDouble(), 8.8))
             .build()
 
         val mapAnimationOption = MapAnimationOptions.mapAnimationOptions { duration(500L) }
 
-        getMapboxMap().easeTo(cameraOption, mapAnimationOption)
+        getMapboxMap().easeTo(cameraOptions, mapAnimationOption)
     }
 
     fun applyInsets(insets: Insets) {
@@ -433,8 +434,8 @@ class BoolderMap @JvmOverloads constructor(
         getMapboxMap().getStyle()?.getLayerAs(layerId)
 
     fun filterGrades(grades: List<String>) {
-        val problemsLayer = getLayerAs<CircleLayer>(MapboxStyleFactory.LAYER_PROBLEMS)
-        val problemsTextLayer = getLayerAs<SymbolLayer>(MapboxStyleFactory.LAYER_PROBLEMS_TEXT)
+        val problemsLayer = getLayerAs<CircleLayer>(LAYER_PROBLEMS)
+        val problemsTextLayer = getLayerAs<SymbolLayer>(LAYER_PROBLEMS_TEXT)
 
         val query = match {
             get("grade")


### PR DESCRIPTION
When filtering on a circuit that spreads over a large area, the zoom was getting so low that it deactivated the area detector and then the circuit filter. This got fixed by limiting the zoom to a minimum value of `15.0`.

https://github.com/boolder-org/boolder-android/assets/8343416/c5f1c1ee-b7c3-40d0-9b29-483be97065cf

There is still a special case for the black circuit of Cuvier that spans over several areas, for which the camera movement triggers a change of area and therefore unselected the the circuit (#58).

Resolves #56 