### PR TITLE
Attempt to fix crash in `LocationProvider`

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
@@ -27,7 +27,6 @@ import com.boolder.boolder.domain.model.GradeRange
 import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.domain.model.Topo
 import com.boolder.boolder.domain.model.TopoOrigin
-import com.boolder.boolder.utils.LocationCallback
 import com.boolder.boolder.utils.LocationProvider
 import com.boolder.boolder.utils.MapboxStyleFactory
 import com.boolder.boolder.utils.extension.launchAndCollectIn
@@ -60,7 +59,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import java.lang.Double.max
 
 
-class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
+class MapActivity : AppCompatActivity(), BoolderMapListener {
 
     private val binding by viewBinding(ActivityMainBinding::inflate)
 
@@ -104,7 +103,8 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
             insets
         }
 
-        locationProvider = LocationProvider(this, this)
+        locationProvider = LocationProvider(this)
+        locationProvider.locationFlow.launchAndCollectIn(owner = this, collector = ::onGPSLocation)
 
         bottomSheetBehavior = BottomSheetBehavior.from(binding.detailBottomSheet).also {
             it.state = STATE_HIDDEN
@@ -204,7 +204,7 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
         super.onDestroy()
     }
 
-    override fun onGPSLocation(location: Location) {
+    private fun onGPSLocation(location: Location) {
         val point = Point.fromLngLat(location.longitude, location.latitude)
         val zoomLevel = max(binding.mapView.getMapboxMap().cameraState.zoom, 17.0)
 


### PR DESCRIPTION
The following crash was happening:
```
Exception java.lang.NullPointerException:
  at com.boolder.boolder.utils.LocationProvider$moveCameraToUserPosition$2.invoke (LocationProvider.kt:101)
  at com.boolder.boolder.utils.LocationProvider$moveCameraToUserPosition$2.invoke (LocationProvider.kt:100)
  at com.boolder.boolder.utils.LocationProvider.moveCameraToUserPosition$lambda$3 (LocationProvider.kt:100)
  at com.boolder.boolder.utils.LocationProvider.$r8$lambda$BBoJsjHP34LgiCfb3988sXjVoq4
  at com.boolder.boolder.utils.LocationProvider$$ExternalSyntheticLambda0.onSuccess
  at com.google.android.gms.tasks.zzm.run (com.google.android.gms:play-services-tasks@@18.0.2:1)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:210)
  at android.os.Looper.loop (Looper.java:299)
  at android.app.ActivityThread.main (ActivityThread.java:8337)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:556)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1037)
```

Apparently, this was due to the invocation of a null callback. In order to fix this crash, the callback mechanism has been replaced by a flow collection, that should not be active when the activity is destroyed.