### PR TITLE
Persist photos for offline usage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
 
     //Mapbox
-    implementation("com.mapbox.maps:android:10.16.0")
+    implementation("com.mapbox.maps:android:10.16.1")
 
     // Play Services
     implementation("com.google.android.gms:play-services-location:21.0.1")
@@ -77,24 +77,30 @@ dependencies {
     implementation("io.insert-koin:koin-android:3.3.3")
 
     // Coil
-    implementation("io.coil-kt:coil:2.4.0")
+    implementation("io.coil-kt:coil:2.5.0")
 
     // Jetpack compose
     val composeBom = platform("androidx.compose:compose-bom:2023.09.00")
     implementation(composeBom)
     androidTestImplementation(composeBom)
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.runtime:runtime-livedata")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.ui:ui-viewbinding")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
-    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.activity:activity-compose:1.8.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.2")
+    implementation("com.google.android.material:material:1.10.0")
     testImplementation("io.insert-koin:koin-test-junit4:3.2.2")
     testImplementation("org.mockito:mockito-core:4.9.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
+
+    // Work manager
+    implementation("androidx.work:work-runtime-ktx:2.8.1")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,9 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Boolder"
         tools:targetApi="31">
+
         <activity android:name=".view.search.SearchActivity" />
+
         <activity
             android:name=".view.map.MapActivity"
             android:screenOrientation="portrait"
@@ -26,6 +28,22 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity android:name=".view.offlinephotos.OfflinePhotosActivity" />
+
+        <!-- Remove default work manager initialization -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <!-- If you are using androidx.startup to initialize other components -->
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/boolder/boolder/AppModule.kt
+++ b/app/src/main/java/com/boolder/boolder/AppModule.kt
@@ -1,0 +1,36 @@
+package com.boolder.boolder
+
+import android.content.res.Resources
+import androidx.work.WorkManager
+import com.boolder.boolder.offline.BoolderOfflineRepository
+import com.boolder.boolder.offline.worker.BoolderWorkerFactory
+import com.mapbox.bindgen.Value
+import com.mapbox.common.TileDataDomain
+import com.mapbox.common.TileStore
+import com.mapbox.common.TileStoreOptions
+import com.mapbox.maps.MapInitOptions
+import com.mapbox.maps.OfflineManager
+import org.koin.android.ext.koin.androidApplication
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.module
+
+val appModule = module {
+    factoryOf(::BoolderWorkerFactory)
+    factoryOf(::BoolderOfflineRepository)
+    factory { WorkManager.getInstance(androidApplication()) }
+    factory { androidApplication().resources }
+
+    factory {
+        OfflineManager(MapInitOptions.getDefaultResourceOptions(androidApplication()))
+    }
+
+    single {
+        TileStore.create().also {
+            it.setOption(
+                TileStoreOptions.MAPBOX_ACCESS_TOKEN,
+                TileDataDomain.MAPS,
+                Value(get<Resources>().getString(R.string.mapbox_access_token))
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/BaseApplication.kt
+++ b/app/src/main/java/com/boolder/boolder/BaseApplication.kt
@@ -1,9 +1,14 @@
 package com.boolder.boolder
 
 import android.app.Application
+import android.util.Log
+import androidx.work.Configuration
+import androidx.work.WorkManager
 import com.boolder.boolder.data.database.databaseModule
 import com.boolder.boolder.data.network.networkModule
 import com.boolder.boolder.view.viewModelModule
+import com.boolder.boolder.offline.worker.BoolderWorkerFactory
+import org.koin.android.ext.android.getKoin
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
@@ -17,7 +22,21 @@ class BaseApplication : Application() {
         startKoin {
             androidLogger(INFO)
             androidContext(this@BaseApplication)
-            modules(listOf(databaseModule, networkModule, viewModelModule))
+            modules(
+                listOf(
+                    appModule,
+                    databaseModule,
+                    networkModule,
+                    viewModelModule
+                )
+            )
         }
+
+        val workManagerConfiguration = Configuration.Builder()
+            .setMinimumLoggingLevel(Log.INFO)
+            .setWorkerFactory(getKoin().get<BoolderWorkerFactory>())
+            .build()
+
+        WorkManager.initialize(this, workManagerConfiguration)
     }
 }

--- a/app/src/main/java/com/boolder/boolder/data/database/dao/AreaDao.kt
+++ b/app/src/main/java/com/boolder/boolder/data/database/dao/AreaDao.kt
@@ -12,4 +12,7 @@ interface AreaDao {
 
     @Query("SELECT * FROM areas WHERE id = :id")
     suspend fun getAreaById(id: Int): AreasEntity
+
+    @Query("SELECT * FROM areas ORDER BY name_searchable ASC")
+    suspend fun getAllAreas(): List<AreasEntity>
 }

--- a/app/src/main/java/com/boolder/boolder/data/database/repository/AreaRepository.kt
+++ b/app/src/main/java/com/boolder/boolder/data/database/repository/AreaRepository.kt
@@ -2,7 +2,8 @@ package com.boolder.boolder.data.database.repository
 
 import com.boolder.boolder.data.database.dao.AreaDao
 import com.boolder.boolder.data.database.entity.AreasEntity
-
+import com.boolder.boolder.domain.convert
+import com.boolder.boolder.domain.model.Area
 
 class AreaRepository(
     private val areaDao: AreaDao
@@ -13,5 +14,7 @@ class AreaRepository(
 
     suspend fun getAreaById(id: Int): AreasEntity =
         areaDao.getAreaById(id)
-}
 
+    suspend fun getAllAreas(): List<Area> =
+        areaDao.getAllAreas().map { it.convert() }
+}

--- a/app/src/main/java/com/boolder/boolder/data/network/KtorClient.kt
+++ b/app/src/main/java/com/boolder/boolder/data/network/KtorClient.kt
@@ -2,13 +2,17 @@ package com.boolder.boolder.data.network
 
 import android.util.Log
 import com.boolder.boolder.data.network.model.TopoRemote
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.engine.okhttp.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.plugins.logging.*
-import io.ktor.client.request.*
-import io.ktor.serialization.kotlinx.json.*
+import com.boolder.boolder.data.network.model.TopoUrl
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.DEFAULT
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.get
+import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
 class KtorClient {
@@ -30,6 +34,17 @@ class KtorClient {
         return try {
             val request = client.get("https://www.boolder.com/api/v1/topos/$topoId")
             val body = request.body<TopoRemote>()
+            Result.success(body)
+        } catch (e: Exception) {
+            Log.e("Ktor Client", e.message ?: "No message")
+            Result.failure(e)
+        }
+    }
+
+    suspend fun loadTopoPicturesForArea(areaId: Int): Result<List<TopoUrl>> {
+        return try {
+            val request = client.get("https://www.boolder.com/api/v1/areas/$areaId/topos.json")
+            val body = request.body<List<TopoUrl>>()
             Result.success(body)
         } catch (e: Exception) {
             Log.e("Ktor Client", e.message ?: "No message")

--- a/app/src/main/java/com/boolder/boolder/data/network/model/TopoUrl.kt
+++ b/app/src/main/java/com/boolder/boolder/data/network/model/TopoUrl.kt
@@ -1,0 +1,10 @@
+package com.boolder.boolder.data.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TopoUrl(
+    @SerialName("topo_id") val id: Int,
+    @SerialName("url") val url: String
+)

--- a/app/src/main/java/com/boolder/boolder/data/network/repository/TopoRepository.kt
+++ b/app/src/main/java/com/boolder/boolder/data/network/repository/TopoRepository.kt
@@ -1,7 +1,7 @@
 package com.boolder.boolder.data.network.repository
 
 import com.boolder.boolder.data.network.KtorClient
-import com.boolder.boolder.data.network.model.TopoRemote
+import com.boolder.boolder.data.network.model.TopoUrl
 
 class TopoRepository(
     private val client: KtorClient
@@ -9,4 +9,7 @@ class TopoRepository(
 
     suspend fun getTopoPictureById(topoId: Int): String? =
         client.loadTopoPicture(topoId).getOrNull()?.url
+
+    suspend fun getTopoPicturesForArea(areaId: Int): List<TopoUrl> =
+        client.loadTopoPicturesForArea(areaId).getOrElse { emptyList() }
 }

--- a/app/src/main/java/com/boolder/boolder/domain/model/Topo.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/model/Topo.kt
@@ -1,11 +1,16 @@
 package com.boolder.boolder.domain.model
 
+import java.io.File
+
 /**
  * Represents the content that should be displayed in the boulder problem
  * details bottom sheet.
  *
  * @param pictureUrl The URL of the picture on which the problem starts and
  * lines will be displayed.
+ * @param imageFile The file that stores the picture on which the problem
+ * starts and lines will be displayed. Non-null when already downloaded for an
+ * offline usage.
  * @param selectedCompleteProblem The problem that is currently displayed in
  * the detail information. Its line should also be shown.
  * @param otherCompleteProblems The problems that are on the same picture, but
@@ -15,6 +20,7 @@ package com.boolder.boolder.domain.model
  */
 data class Topo(
     val pictureUrl: String?,
+    val imageFile: File?,
     val selectedCompleteProblem: CompleteProblem?,
     val otherCompleteProblems: List<CompleteProblem>,
     val circuitInfo: CircuitInfo?,

--- a/app/src/main/java/com/boolder/boolder/offline/BoolderOfflineRepository.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/BoolderOfflineRepository.kt
@@ -1,0 +1,68 @@
+package com.boolder.boolder.offline
+
+import androidx.work.BackoffPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.WorkRequest
+import androidx.work.workDataOf
+import com.boolder.boolder.offline.worker.PhotosDownloadWorker
+import com.boolder.boolder.utils.FileSizeFormatter
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
+import com.mapbox.common.TileStore
+import java.util.concurrent.TimeUnit
+
+class BoolderOfflineRepository(
+    private val workManager: WorkManager,
+    private val fileExplorer: FileExplorer,
+    private val fileSizeFormatter: FileSizeFormatter,
+    private val tileStore: TileStore
+) {
+
+    fun getStatusForAreaId(areaId: Int): OfflineAreaItemStatus {
+        val isDownloading = workManager
+            .getWorkInfosForUniqueWork(areaId.getDownloadTopoImagesWorkName())
+            .get()
+            .any { it.state == WorkInfo.State.ENQUEUED || it.state == WorkInfo.State.RUNNING }
+
+        if (isDownloading) return OfflineAreaItemStatus.Downloading(areaId)
+
+        val areaFolderSize = fileExplorer.areaFolderSize(areaId)
+
+        return when (areaFolderSize > 0L) {
+            true -> OfflineAreaItemStatus.Downloaded(
+                folderSize = fileSizeFormatter.formatBytesSize(areaFolderSize)
+            )
+            else -> OfflineAreaItemStatus.NotDownloaded
+        }
+    }
+
+    fun downloadArea(areaId: Int) {
+        val workInputData = workDataOf("areaId" to areaId)
+        val downloadPhotosTask = OneTimeWorkRequestBuilder<PhotosDownloadWorker>()
+            .setInputData(workInputData)
+            .addTag("download-topo-images-$areaId")
+            .setBackoffCriteria(
+                backoffPolicy = BackoffPolicy.EXPONENTIAL,
+                backoffDelay = WorkRequest.MIN_BACKOFF_MILLIS,
+                timeUnit = TimeUnit.SECONDS
+            )
+            .build()
+
+        workManager.enqueueUniqueWork(
+            areaId.getDownloadTopoImagesWorkName(),
+            ExistingWorkPolicy.KEEP,
+            downloadPhotosTask
+        )
+    }
+
+    fun cancelAreaDownload(areaId: Int) {
+        workManager.cancelUniqueWork(areaId.getDownloadTopoImagesWorkName())
+    }
+
+    fun deleteArea(areaId: Int) {
+        tileStore.removeTileRegion("map-tiles-area-$areaId")
+        fileExplorer.deleteFolder(areaId)
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/offline/Constants.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/Constants.kt
@@ -1,0 +1,13 @@
+package com.boolder.boolder.offline
+
+import androidx.work.WorkInfo
+
+// Progress keys
+const val WORK_DATA_PROGRESS = "progress"
+const val WORK_DATA_PROGRESS_DETAIL = "progress_detail"
+
+val DOWNLOAD_TERMINATED_STATUSES = arrayOf(
+    WorkInfo.State.SUCCEEDED,
+    WorkInfo.State.FAILED,
+    WorkInfo.State.CANCELLED
+)

--- a/app/src/main/java/com/boolder/boolder/offline/Extensions.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/Extensions.kt
@@ -1,0 +1,4 @@
+package com.boolder.boolder.offline
+
+fun Int.getDownloadTopoImagesWorkName() =
+    "download-topo-images-$this"

--- a/app/src/main/java/com/boolder/boolder/offline/FileExplorer.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/FileExplorer.kt
@@ -1,0 +1,31 @@
+package com.boolder.boolder.offline
+
+import android.content.Context
+import java.io.File
+
+class FileExplorer(private val context: Context) {
+
+    fun getTopoImageFile(areaId: Int, topoId: Int): File? {
+        val areaFolder = context.getDir(areaId.toString(), Context.MODE_PRIVATE)
+        val imageFile = File(areaFolder, topoId.toString())
+
+        return imageFile.takeIf { it.exists() }
+    }
+
+    fun areaFolderSize(areaId: Int): Long {
+        val areaFolder = context.getDir(areaId.toString(), Context.MODE_PRIVATE)
+
+        return areaFolder
+            ?.listFiles()
+            ?.sumOf { it.length() }
+            ?: 0L
+    }
+
+    fun deleteFolder(areaId: Int) {
+        val areaFolder = context.getDir(areaId.toString(), Context.MODE_PRIVATE)
+        val folderContents = areaFolder?.listFiles() ?: emptyArray()
+
+        folderContents.forEach { it.delete() }
+        areaFolder.delete()
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/offline/OfflineAreaDownloader.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/OfflineAreaDownloader.kt
@@ -1,0 +1,13 @@
+package com.boolder.boolder.offline
+
+interface OfflineAreaDownloader {
+    fun onDownloadArea(areaId: Int)
+    fun onCancelAreaDownload(areaId: Int)
+    fun onAreaDownloadTerminated(areaId: Int)
+}
+
+fun dummyOfflineAreaDownloader() = object : OfflineAreaDownloader {
+    override fun onDownloadArea(areaId: Int) {}
+    override fun onCancelAreaDownload(areaId: Int) {}
+    override fun onAreaDownloadTerminated(areaId: Int) {}
+}

--- a/app/src/main/java/com/boolder/boolder/offline/worker/BoolderWorkerFactory.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/worker/BoolderWorkerFactory.kt
@@ -1,0 +1,50 @@
+package com.boolder.boolder.offline.worker
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import com.boolder.boolder.data.database.repository.AreaRepository
+import com.boolder.boolder.data.network.repository.TopoRepository
+import com.boolder.boolder.offline.FileExplorer
+import com.mapbox.common.TileStore
+import com.mapbox.maps.OfflineManager
+
+class BoolderWorkerFactory(
+    private val areaRepository: AreaRepository,
+    private val topoRepository: TopoRepository,
+    private val fileExplorer: FileExplorer,
+    private val offlineManager: OfflineManager,
+    private val tileStore: TileStore
+) : WorkerFactory() {
+
+    override fun createWorker(
+        appContext: Context,
+        workerClassName: String,
+        workerParameters: WorkerParameters
+    ): ListenableWorker? =
+        when (workerClassName) {
+            MapStylePackDownloadWorker::class.java.name -> MapStylePackDownloadWorker(
+                appContext = appContext,
+                params = workerParameters,
+                offlineManager = offlineManager
+            )
+
+            MapTilesDownloadWorker::class.java.name -> MapTilesDownloadWorker(
+                appContext = appContext,
+                params = workerParameters,
+                areaRepository = areaRepository,
+                offlineManager = offlineManager,
+                tileStore = tileStore
+            )
+
+            PhotosDownloadWorker::class.java.name -> PhotosDownloadWorker(
+                appContext = appContext,
+                params = workerParameters,
+                topoRepository = topoRepository,
+                fileExplorer = fileExplorer
+            )
+
+            else -> null
+        }
+}

--- a/app/src/main/java/com/boolder/boolder/offline/worker/MapStylePackDownloadWorker.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/worker/MapStylePackDownloadWorker.kt
@@ -1,0 +1,94 @@
+package com.boolder.boolder.offline.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.boolder.boolder.domain.model.BoolderMapConfig
+import com.boolder.boolder.offline.WORK_DATA_PROGRESS
+import com.boolder.boolder.offline.WORK_DATA_PROGRESS_DETAIL
+import com.boolder.boolder.utils.extension.getAllStylePacksAsync
+import com.boolder.boolder.utils.extension.loadStylePackAsync
+import com.mapbox.bindgen.Value
+import com.mapbox.maps.GlyphsRasterizationMode
+import com.mapbox.maps.OfflineManager
+import com.mapbox.maps.StylePackLoadOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class MapStylePackDownloadWorker(
+    appContext: Context,
+    params: WorkerParameters,
+    private val offlineManager: OfflineManager
+) : CoroutineWorker(appContext, params) {
+
+    private var retryCount = 0
+
+    override suspend fun doWork(): Result =
+        withContext(Dispatchers.Main) { downloadStylePack() }
+
+    private suspend fun downloadStylePack(): Result {
+        offlineManager.getAllStylePacksAsync().value?.let { stylePackList ->
+            Log.d(TAG, "Existing style packs: $stylePackList")
+
+            if (stylePackList.any { it.styleURI == BoolderMapConfig.styleUri }) {
+                return Result.success()
+            }
+        }
+
+        setProgress(
+            workDataOf(
+                WORK_DATA_PROGRESS to 0,
+                WORK_DATA_PROGRESS_DETAIL to "0%"
+            )
+        )
+
+        val stylePackLoadOptions = StylePackLoadOptions.Builder()
+            .glyphsRasterizationMode(GlyphsRasterizationMode.IDEOGRAPHS_RASTERIZED_LOCALLY)
+            .acceptExpired(false)
+            .metadata(Value("boolder-map-style-pack"))
+            .build()
+
+        val stylePackLoadingResult = offlineManager.loadStylePackAsync(
+            styleUri = BoolderMapConfig.styleUri,
+            stylePackLoadOptions = stylePackLoadOptions,
+            onProgress = { progress ->
+                val progressRatio = with(progress) {
+                    completedResourceCount.toFloat() / requiredResourceCount.toFloat()
+                }
+
+                setProgressAsync(
+                    workDataOf(
+                        WORK_DATA_PROGRESS to progressRatio,
+                        WORK_DATA_PROGRESS_DETAIL to String.format("%.2f%%", progressRatio * 100)
+                    )
+                )
+
+                Log.d(TAG, "Style pack progress = $progressRatio")
+            }
+        )
+
+        if (stylePackLoadingResult.isValue) {
+            Log.d(TAG, "Style pack download completed (exp: ${stylePackLoadingResult.value?.expires})")
+        } else {
+            Log.e(TAG, "Style pack download failed (${stylePackLoadingResult.error?.message})")
+
+            if (retryCount < RETRY_LIMIT) return Result.retry()
+
+            return Result.failure()
+        }
+
+        offlineManager.getAllStylePacksAsync().value?.let { stylePackList ->
+            Log.d(TAG, "Existing style packs: $stylePackList")
+        }
+
+        return Result.success()
+    }
+
+    companion object {
+        private val TAG = MapStylePackDownloadWorker::class.java.simpleName
+
+        private const val RETRY_LIMIT = 3
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/offline/worker/MapTilesDownloadWorker.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/worker/MapTilesDownloadWorker.kt
@@ -1,0 +1,140 @@
+package com.boolder.boolder.offline.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.boolder.boolder.data.database.repository.AreaRepository
+import com.boolder.boolder.domain.convert
+import com.boolder.boolder.domain.model.BoolderMapConfig
+import com.boolder.boolder.offline.WORK_DATA_PROGRESS
+import com.boolder.boolder.offline.WORK_DATA_PROGRESS_DETAIL
+import com.boolder.boolder.utils.extension.getAllTileRegionsAsync
+import com.boolder.boolder.utils.extension.loadTileRegionAsync
+import com.mapbox.bindgen.Value
+import com.mapbox.common.NetworkRestriction
+import com.mapbox.common.TileRegionLoadOptions
+import com.mapbox.common.TileStore
+import com.mapbox.geojson.Geometry
+import com.mapbox.geojson.Point
+import com.mapbox.geojson.Polygon
+import com.mapbox.maps.OfflineManager
+import com.mapbox.maps.TilesetDescriptorOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class MapTilesDownloadWorker(
+    appContext: Context,
+    params: WorkerParameters,
+    private val areaRepository: AreaRepository,
+    private val offlineManager: OfflineManager,
+    private val tileStore: TileStore
+) : CoroutineWorker(appContext, params) {
+
+    private var retryCount = 0
+
+    override suspend fun doWork(): Result {
+        val areaId = inputData.getInt("areaId", -1)
+            .takeIf { it >= 0 }
+            ?: return Result.failure()
+
+        val areaGeometry = areaRepository.getAreaById(areaId)
+            .convert()
+            .let {
+                val northLat = it.northEastLat.toDouble()
+                val southLat = it.southWestLat.toDouble()
+                val westLng = it.southWestLon.toDouble()
+                val eastLng = it.northEastLon.toDouble()
+
+                Polygon.fromLngLats(
+                    listOf(
+                        listOf(
+                            Point.fromLngLat(westLng, northLat),
+                            Point.fromLngLat(eastLng, northLat),
+                            Point.fromLngLat(eastLng, southLat),
+                            Point.fromLngLat(westLng, southLat),
+                        )
+                    )
+                )
+            }
+
+        return withContext(Dispatchers.Main) {
+            downloadTileRegion(
+                areaId = areaId,
+                areaGeometry = areaGeometry
+            )
+        }
+    }
+
+    private suspend fun downloadTileRegion(
+        areaId: Int,
+        areaGeometry: Geometry
+    ): Result {
+        setProgress(
+            workDataOf(
+                WORK_DATA_PROGRESS to 0,
+                WORK_DATA_PROGRESS_DETAIL to "0%"
+            )
+        )
+
+        val id = "map-tiles-area-$areaId"
+
+        val tilesetDescriptor = offlineManager.createTilesetDescriptor(
+            TilesetDescriptorOptions.Builder()
+                .styleURI(BoolderMapConfig.styleUri)
+                .minZoom(0)
+                .maxZoom(16)
+                .build()
+        )
+
+        val tileRegionLoadOptions = TileRegionLoadOptions.Builder()
+            .geometry(areaGeometry)
+            .descriptors(listOf(tilesetDescriptor))
+            .acceptExpired(false)
+            .networkRestriction(NetworkRestriction.NONE)
+            .metadata(Value(id))
+            .build()
+
+        val tileRegionLoadingResult = tileStore.loadTileRegionAsync(
+            id = id,
+            tileRegionLoadOptions = tileRegionLoadOptions,
+            onProgress = { progress ->
+                val progressRatio = with(progress) {
+                    completedResourceCount.toFloat() / requiredResourceCount.toFloat()
+                }
+
+                setProgressAsync(
+                    workDataOf(
+                        WORK_DATA_PROGRESS to progressRatio,
+                        WORK_DATA_PROGRESS_DETAIL to String.format("%.2f%%", progressRatio * 100)
+                    )
+                )
+
+                Log.d(TAG, "Tile pack download progress = $progressRatio")
+            }
+        )
+
+        if (tileRegionLoadingResult.isValue) {
+            Log.d(TAG, "Tile pack download completed (exp: ${tileRegionLoadingResult.value?.expires})")
+        } else {
+            Log.e(TAG, "Tile pack download failed (${tileRegionLoadingResult.error?.message})")
+
+            if (retryCount < RETRY_LIMIT) return Result.retry()
+
+            return Result.failure()
+        }
+
+        tileStore.getAllTileRegionsAsync().value?.let { tileRegionList ->
+            Log.d(TAG, "Existing tile regions: $tileRegionList")
+        }
+
+        return Result.success()
+    }
+
+    companion object {
+        private val TAG = MapTilesDownloadWorker::class.java.simpleName
+
+        private const val RETRY_LIMIT = 3
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/offline/worker/PhotosDownloadWorker.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/worker/PhotosDownloadWorker.kt
@@ -1,0 +1,112 @@
+package com.boolder.boolder.offline.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.boolder.boolder.data.network.model.TopoUrl
+import com.boolder.boolder.data.network.repository.TopoRepository
+import com.boolder.boolder.offline.WORK_DATA_PROGRESS
+import com.boolder.boolder.offline.WORK_DATA_PROGRESS_DETAIL
+import com.boolder.boolder.offline.FileExplorer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.buffer
+import okio.sink
+import java.io.File
+
+class PhotosDownloadWorker(
+    appContext: Context,
+    params: WorkerParameters,
+    private val topoRepository: TopoRepository,
+    private val fileExplorer: FileExplorer
+) : CoroutineWorker(appContext, params) {
+
+    private val client = OkHttpClient()
+
+    override suspend fun doWork(): Result {
+        val areaId = inputData.getInt("areaId", -1)
+            .takeIf { it >= 0 }
+            ?: return Result.failure()
+
+        val topoPhotoUrls = topoRepository.getTopoPicturesForArea(areaId)
+
+        downloadPhotos(
+            areaId = areaId,
+            topoPhotoUrls = topoPhotoUrls
+        )
+
+        return Result.success()
+    }
+
+    private suspend fun downloadPhotos(
+        areaId: Int,
+        topoPhotoUrls: List<TopoUrl>
+    ) {
+        if (fileExplorer.areaFolderSize(areaId) > 0) return
+
+        val assetsFolder = applicationContext.getDir(areaId.toString(), Context.MODE_PRIVATE)
+
+        setProgress(
+            workDataOf(
+                WORK_DATA_PROGRESS to 0,
+                WORK_DATA_PROGRESS_DETAIL to "0/${topoPhotoUrls.size}"
+            )
+        )
+
+        withContext(Dispatchers.IO) {
+            topoPhotoUrls.forEachIndexed { index, (topoId, imageUrl) ->
+                downloadPhoto(assetsFolder, topoId, imageUrl)
+
+                val progress = (index + 1).toFloat() / topoPhotoUrls.size.toFloat()
+
+                Log.d(TAG, "Progress = $progress %")
+                setProgress(
+                    workDataOf(
+                        WORK_DATA_PROGRESS to progress,
+                        WORK_DATA_PROGRESS_DETAIL to "${index + 1}/${topoPhotoUrls.size}"
+                    )
+                )
+            }
+        }
+    }
+
+    private fun downloadPhoto(folder: File, topoId: Int, imageUrl: String) {
+        val request = Request.Builder()
+            .url(imageUrl)
+            .build()
+
+        client.newCall(request)
+            .execute()
+            .use { response ->
+                if (!response.isSuccessful) {
+                    Log.d(TAG, "Error downloading topo image $topoId, $imageUrl: $response")
+                    return@use
+                }
+
+                val bufferedSource = response.body?.source() ?: return@use
+
+                val imageFile = File(folder, topoId.toString())
+
+                if (imageFile.exists()) return@use
+
+                Log.d(TAG, "Writing $topoId - $imageUrl...")
+
+                val bufferedSink = imageFile.sink().buffer()
+
+                bufferedSink.writeAll(bufferedSource)
+                bufferedSink.close()
+
+                Log.d(TAG, "Successfully wrote $topoId - $imageUrl")
+            }
+
+        Log.d(TAG, "Downloads finished")
+    }
+
+    companion object {
+        private const val TAG = "ContentDownloader"
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/utils/FileSizeFormatter.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/FileSizeFormatter.kt
@@ -1,0 +1,26 @@
+package com.boolder.boolder.utils
+
+class FileSizeFormatter {
+
+    fun formatBytesSize(bytesSize: Long): String {
+        var currentSize = bytesSize.toDouble()
+
+        if (currentSize < BYTES_UNIT_FACTOR) {
+            return String.format("%.2f B", currentSize)
+        }
+
+        currentSize /= BYTES_UNIT_FACTOR
+
+        if (currentSize < BYTES_UNIT_FACTOR) {
+            return String.format("%.2f kB", currentSize)
+        }
+
+        currentSize /= BYTES_UNIT_FACTOR
+
+        return String.format("%.2f MB", currentSize)
+    }
+
+    companion object {
+        private const val BYTES_UNIT_FACTOR = 1024.0
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/utils/extension/MapboxOfflineExtensions.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/extension/MapboxOfflineExtensions.kt
@@ -1,0 +1,53 @@
+package com.boolder.boolder.utils.extension
+
+import com.mapbox.common.TileRegionLoadOptions
+import com.mapbox.common.TileRegionLoadProgress
+import com.mapbox.common.TileStore
+import com.mapbox.maps.OfflineManager
+import com.mapbox.maps.StylePackLoadOptions
+import com.mapbox.maps.StylePackLoadProgress
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+suspend fun OfflineManager.getAllStylePacksAsync() =
+    suspendCoroutine { continuation ->
+        getAllStylePacks(continuation::resume)
+    }
+
+suspend fun OfflineManager.loadStylePackAsync(
+    styleUri: String,
+    stylePackLoadOptions: StylePackLoadOptions,
+    onProgress: (StylePackLoadProgress) -> Unit
+) =
+    suspendCancellableCoroutine { continuation ->
+        val cancellableTask = loadStylePack(
+            styleUri,
+            stylePackLoadOptions,
+            { onProgress(it) },
+            { result -> continuation.resume(result) }
+        )
+
+        continuation.invokeOnCancellation { cancellableTask.cancel() }
+    }
+
+suspend fun TileStore.getAllTileRegionsAsync() =
+    suspendCoroutine { continuation ->
+        getAllTileRegions(continuation::resume)
+    }
+
+suspend fun TileStore.loadTileRegionAsync(
+    id: String,
+    tileRegionLoadOptions: TileRegionLoadOptions,
+    onProgress: (TileRegionLoadProgress) -> Unit
+) =
+    suspendCancellableCoroutine { continuation ->
+        val cancelableTask = loadTileRegion(
+            id,
+            tileRegionLoadOptions,
+            { onProgress(it) },
+            { result -> continuation.resume(result) }
+        )
+
+        continuation.invokeOnCancellation { cancelableTask.cancel() }
+    }

--- a/app/src/main/java/com/boolder/boolder/utils/previewgenerator/AreaGenerator.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/previewgenerator/AreaGenerator.kt
@@ -1,0 +1,12 @@
+package com.boolder.boolder.utils.previewgenerator
+
+import com.boolder.boolder.domain.model.Area
+
+fun dummyArea() = Area(
+    id = 1,
+    name = "Rocher Canon",
+    southWestLat = 0f,
+    southWestLon = 0f,
+    northEastLat = 0f,
+    northEastLon = 0f
+)

--- a/app/src/main/java/com/boolder/boolder/utils/previewgenerator/OfflineAreaItemGenerator.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/previewgenerator/OfflineAreaItemGenerator.kt
@@ -1,0 +1,11 @@
+package com.boolder.boolder.utils.previewgenerator
+
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
+
+fun dummyOfflineAreaItem(
+    status: OfflineAreaItemStatus = OfflineAreaItemStatus.NotDownloaded
+) = OfflineAreaItem(
+    area = dummyArea(),
+    status = status
+)

--- a/app/src/main/java/com/boolder/boolder/view/ViewModules.kt
+++ b/app/src/main/java/com/boolder/boolder/view/ViewModules.kt
@@ -1,14 +1,19 @@
 package com.boolder.boolder.view
 
 import android.content.res.Resources
+import com.boolder.boolder.utils.FileSizeFormatter
 import com.boolder.boolder.utils.MapboxStyleFactory
 import com.boolder.boolder.utils.NetworkObserverImpl
 import com.boolder.boolder.view.map.MapViewModel
 import com.boolder.boolder.view.map.TopoDataAggregator
 import com.boolder.boolder.view.map.filter.grade.GradesFilterViewModel
+import com.boolder.boolder.view.offlinephotos.OfflinePhotosViewModel
+import com.boolder.boolder.view.offlinephotos.OfflinePhotosViewModelImpl
 import com.boolder.boolder.view.search.SearchViewModel
+import com.boolder.boolder.offline.FileExplorer
 import org.koin.android.ext.koin.androidApplication
 import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.core.module.dsl.binds
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
@@ -23,4 +28,8 @@ val viewModelModule = module {
     factoryOf(::TopoDataAggregator)
 
     viewModelOf(::GradesFilterViewModel)
+
+    viewModelOf(::OfflinePhotosViewModelImpl) { binds(listOf(OfflinePhotosViewModel::class)) }
+    factory { FileExplorer(androidApplication()) }
+    factory { FileSizeFormatter() }
 }

--- a/app/src/main/java/com/boolder/boolder/view/detail/TopoView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/TopoView.kt
@@ -6,9 +6,14 @@ import android.net.Uri
 import android.util.AttributeSet
 import android.util.Log
 import android.view.LayoutInflater
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -40,6 +45,19 @@ class TopoView(
 
     var onSelectProblemOnMap: ((problemId: String) -> Unit)? = null
     var onCircuitProblemSelected: ((problemId: Int) -> Unit)? = null
+
+    init {
+        // Immediately set a footer content to avoid a bug on the bottom sheet not fully expanding
+        // on the first time it is expanded
+        binding.footerLayout.setContent {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(210.dp)
+                    .background(color = Color.White)
+            )
+        }
+    }
 
     fun setTopo(topo: Topo) {
         setUiProblems(
@@ -146,22 +164,17 @@ class TopoView(
     private fun loadTopoImage(topo: Topo) {
         binding.progressCircular.isVisible = true
 
-        if (topo.pictureUrl == null) {
-            loadErrorPicture()
-            return
-        }
+        val imageData = topo.imageFile ?: topo.pictureUrl
 
-        binding.picture.load(topo.pictureUrl) {
+        binding.picture.load(imageData) {
             crossfade(true)
             error(R.drawable.ic_placeholder)
 
             listener(
                 onSuccess = { _, _ ->
-                    context?.let {
-                        binding.picture.setPadding(0)
-                        binding.progressCircular.isVisible = false
-                        onProblemPictureLoaded(topo)
-                    }
+                    binding.picture.setPadding(0)
+                    binding.progressCircular.isVisible = false
+                    onProblemPictureLoaded(topo)
                 },
                 onError = { _, _ -> loadErrorPicture() }
             )

--- a/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapActivity.kt
@@ -40,6 +40,7 @@ import com.boolder.boolder.view.map.filter.circuit.CircuitFilterBottomSheetDialo
 import com.boolder.boolder.view.map.filter.circuit.CircuitFilterBottomSheetDialogFragment.Companion.RESULT_CIRCUIT
 import com.boolder.boolder.view.map.filter.grade.GradesFilterBottomSheetDialogFragment
 import com.boolder.boolder.view.map.filter.grade.GradesFilterBottomSheetDialogFragment.Companion.RESULT_GRADE_RANGE
+import com.boolder.boolder.view.offlinephotos.OfflinePhotosActivity
 import com.boolder.boolder.view.search.SearchActivity
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
@@ -107,6 +108,7 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
         locationProvider = LocationProvider(this, this)
 
         bottomSheetBehavior = BottomSheetBehavior.from(binding.detailBottomSheet).also {
+            it.skipCollapsed = true
             it.state = STATE_HIDDEN
             it.addBottomSheetCallback(object : BottomSheetCallback() {
                 override fun onStateChanged(bottomSheet: View, newState: Int) {
@@ -127,6 +129,10 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
             locationProvider.askForPosition()
         }
 
+//        binding.offlinePhotosButton.setOnClickListener {
+//            startActivity(Intent(this, OfflinePhotosActivity::class.java))
+//        }
+
         binding.topoView.apply {
             onSelectProblemOnMap = { problemId ->
                 binding.mapView.selectProblem(problemId)
@@ -143,11 +149,12 @@ class MapActivity : AppCompatActivity(), LocationCallback, BoolderMapListener {
             binding.controlsOverlayComposeView.setContent {
                 BoolderTheme {
                     MapControlsOverlay(
-                        areaName = screenState.areaState?.name,
+                        offlineAreaItem = screenState.areaState,
                         circuitState = screenState.circuitState,
                         gradeState = screenState.gradeState,
                         popularState = screenState.popularFilterState,
                         shouldShowFiltersBar = screenState.shouldShowFiltersBar,
+                        offlineAreaDownloader = mapViewModel,
                         onHideAreaName = ::onAreaLeft,
                         onSearchBarClicked = ::navigateToSearchScreen,
                         onCircuitFilterChipClicked = mapViewModel::onCircuitFilterChipClicked,

--- a/app/src/main/java/com/boolder/boolder/view/map/TopoDataAggregator.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/TopoDataAggregator.kt
@@ -11,11 +11,13 @@ import com.boolder.boolder.domain.model.CompleteProblem
 import com.boolder.boolder.domain.model.ProblemWithLine
 import com.boolder.boolder.domain.model.Topo
 import com.boolder.boolder.domain.model.TopoOrigin
+import com.boolder.boolder.offline.FileExplorer
 
 class TopoDataAggregator(
     private val topoRepository: TopoRepository,
     private val problemRepository: ProblemRepository,
-    private val lineRepository: LineRepository
+    private val lineRepository: LineRepository,
+    private val fileExplorer: FileExplorer
 ) {
 
     suspend fun aggregate(problemId: Int, origin: TopoOrigin): Topo {
@@ -24,6 +26,10 @@ class TopoDataAggregator(
         val mainLine = lineRepository.loadByProblemId(problemId)
 
         val topoId = mainLine?.topoId
+
+        val imageFile = topoId?.let {
+            fileExplorer.getTopoImageFile(areaId = mainProblem.areaId, topoId = it)
+        }
 
         val topoPictureUrl = topoId?.let { topoRepository.getTopoPictureById(it) }
 
@@ -47,6 +53,7 @@ class TopoDataAggregator(
 
         return Topo(
             pictureUrl = topoPictureUrl,
+            imageFile = imageFile,
             selectedCompleteProblem = mainCompleteProblem,
             otherCompleteProblems = otherCompleteProblems,
             circuitInfo = CircuitInfo(
@@ -158,6 +165,7 @@ class TopoDataAggregator(
     companion object {
         private val EMPTY_TOPO = Topo(
             pictureUrl = null,
+            imageFile = null,
             selectedCompleteProblem = null,
             otherCompleteProblems = emptyList(),
             circuitInfo = null,

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/AreaName.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/AreaName.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,32 +14,52 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import com.boolder.boolder.R
+import com.boolder.boolder.offline.DOWNLOAD_TERMINATED_STATUSES
+import com.boolder.boolder.offline.OfflineAreaDownloader
+import com.boolder.boolder.offline.WORK_DATA_PROGRESS
+import com.boolder.boolder.offline.dummyOfflineAreaDownloader
+import com.boolder.boolder.offline.getDownloadTopoImagesWorkName
+import com.boolder.boolder.utils.previewgenerator.dummyOfflineAreaItem
 import com.boolder.boolder.view.compose.BoolderTheme
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
+import kotlin.math.roundToInt
 
 @Composable
 internal fun AreaName(
-    name: String?,
+    offlineAreaItem: OfflineAreaItem?,
+    offlineAreaDownloader: OfflineAreaDownloader,
     onHideAreaName: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val alpha by animateFloatAsState(
-        targetValue = if (name == null) 0f else 1f,
+        targetValue = if (offlineAreaItem == null) 0f else 1f,
         animationSpec = tween(durationMillis = 300),
         label = "alpha animation"
     )
@@ -63,28 +84,174 @@ internal fun AreaName(
             contentDescription = "Hide area name"
         )
 
-        Text(
+        Row(
             modifier = Modifier
                 .weight(1f)
                 .padding(8.dp),
-            text = name.orEmpty(),
-            textAlign = TextAlign.Center,
-            fontSize = 18.sp,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
+            horizontalArrangement = spacedBy(4.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = offlineAreaItem?.area?.name.orEmpty(),
+                textAlign = TextAlign.Center,
+                fontSize = 18.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
 
-        Spacer(modifier = Modifier.width(48.dp))
+            AreaOfflineStatusInfo(item = offlineAreaItem)
+        }
+
+        AreaOfflineStatusAction(
+            item = offlineAreaItem,
+            offlineAreaDownloader = offlineAreaDownloader
+        )
     }
+}
+
+@Composable
+private fun AreaOfflineStatusInfo(item: OfflineAreaItem?) {
+    item ?: return
+
+    when (val status = item.status) {
+        is OfflineAreaItemStatus.NotDownloaded -> Unit
+        is OfflineAreaItemStatus.Downloading -> AreaDownloadProgress(areaId = status.areaId)
+        is OfflineAreaItemStatus.Downloaded -> IconDownloaded()
+    }
+}
+
+@Composable
+private fun AreaDownloadProgress(areaId: Int) {
+    if (LocalInspectionMode.current) {
+        AreaDownloadProgress(progress = .34f)
+        return
+    }
+
+    val workInfoList by WorkManager.getInstance(LocalContext.current)
+        .getWorkInfosForUniqueWorkLiveData(areaId.getDownloadTopoImagesWorkName())
+        .observeAsState()
+
+    val workInfo = workInfoList
+        ?.firstOrNull { it.state == WorkInfo.State.RUNNING }
+        ?: return
+
+    val progress = workInfo.progress
+        .getFloat(WORK_DATA_PROGRESS, 0f)
+
+    AreaDownloadProgress(progress = progress)
+}
+
+@Composable
+private fun AreaDownloadProgress(progress: Float) {
+    Row(
+        horizontalArrangement = spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "${(progress * 100f).roundToInt()}%",
+            style = MaterialTheme.typography.bodySmall
+        )
+        CircularProgressIndicator(
+            modifier = Modifier.size(16.dp),
+            strokeCap = StrokeCap.Round
+        )
+    }
+}
+
+@Composable
+private fun AreaOfflineStatusAction(
+    item: OfflineAreaItem?,
+    offlineAreaDownloader: OfflineAreaDownloader
+) {
+    item ?: return
+
+    when (item.status) {
+        is OfflineAreaItemStatus.NotDownloaded -> IconNotDownloaded(
+            modifier = Modifier.statusIconModifier { offlineAreaDownloader.onDownloadArea(item.area.id) }
+        )
+        is OfflineAreaItemStatus.Downloading -> IconDownloading(
+            modifier = Modifier.statusIconModifier { offlineAreaDownloader.onCancelAreaDownload(item.area.id) },
+            areaId = item.area.id,
+            onDownloadTerminated = offlineAreaDownloader::onAreaDownloadTerminated
+        )
+        is OfflineAreaItemStatus.Downloaded -> Spacer(modifier = Modifier.width(48.dp))
+    }
+}
+
+private fun Modifier.statusIconModifier(onClick: () -> Unit) =
+    padding(4.dp)
+        .clip(shape = CircleShape)
+        .clickable(onClick = onClick)
+        .padding(8.dp)
+        .size(24.dp)
+
+@Composable
+private fun IconNotDownloaded(
+    modifier: Modifier = Modifier
+) {
+    Icon(
+        modifier = modifier,
+        painter = painterResource(id = R.drawable.ic_download_for_offline),
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.primary
+    )
+}
+
+@Composable
+private fun IconDownloading(
+    areaId: Int,
+    onDownloadTerminated: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (!LocalInspectionMode.current) {
+        val workInfoList by WorkManager.getInstance(LocalContext.current)
+            .getWorkInfosForUniqueWorkLiveData(areaId.getDownloadTopoImagesWorkName())
+            .observeAsState()
+
+        if (workInfoList?.all { it.state in DOWNLOAD_TERMINATED_STATUSES } == true) {
+            onDownloadTerminated(areaId)
+        }
+    }
+
+    Icon(
+        modifier = modifier,
+        painter = painterResource(id = R.drawable.ic_cancel),
+        contentDescription = null,
+        tint = Color.Gray
+    )
+}
+
+@Composable
+private fun IconDownloaded(
+    modifier: Modifier = Modifier
+) {
+    Icon(
+        modifier = modifier,
+        painter = painterResource(id = R.drawable.ic_download_done),
+        contentDescription = null,
+        tint = Color.Gray
+    )
 }
 
 @Preview
 @Composable
-private fun AreaNamePreview() {
+private fun AreaNamePreview(
+    @PreviewParameter(AreaNamePreviewParameterProvider::class)
+    offlineAreaItemStatus: OfflineAreaItemStatus
+) {
     BoolderTheme {
         AreaName(
-            name = "Rocher canon",
+            offlineAreaItem = dummyOfflineAreaItem(status = offlineAreaItemStatus),
+            offlineAreaDownloader = dummyOfflineAreaDownloader(),
             onHideAreaName = {}
         )
     }
+}
+
+class AreaNamePreviewParameterProvider : PreviewParameterProvider<OfflineAreaItemStatus> {
+    override val values = sequenceOf(
+        OfflineAreaItemStatus.NotDownloaded,
+        OfflineAreaItemStatus.Downloading(areaId = 0),
+        OfflineAreaItemStatus.Downloaded(folderSize = "50 MB")
+    )
 }

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/MapControlsOverlay.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/MapControlsOverlay.kt
@@ -18,17 +18,23 @@ import androidx.compose.ui.unit.dp
 import com.boolder.boolder.R
 import com.boolder.boolder.domain.model.ALL_GRADES
 import com.boolder.boolder.domain.model.CircuitColor
+import com.boolder.boolder.offline.OfflineAreaDownloader
+import com.boolder.boolder.offline.dummyOfflineAreaDownloader
 import com.boolder.boolder.utils.extension.composeColor
+import com.boolder.boolder.utils.previewgenerator.dummyArea
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.map.MapViewModel
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
 
 @Composable
 fun MapControlsOverlay(
-    areaName: String?,
+    offlineAreaItem: OfflineAreaItem?,
     circuitState: MapViewModel.CircuitState?,
     gradeState: MapViewModel.GradeState,
     popularState: MapViewModel.PopularFilterState,
     shouldShowFiltersBar: Boolean,
+    offlineAreaDownloader: OfflineAreaDownloader,
     onHideAreaName: () -> Unit,
     onSearchBarClicked: () -> Unit,
     onCircuitFilterChipClicked: () -> Unit,
@@ -42,17 +48,18 @@ fun MapControlsOverlay(
         modifier = modifier.systemBarsPadding()
     ) {
         MapHeaderLayout(
-            areaName = areaName,
+            offlineAreaItem = offlineAreaItem,
             circuitState = circuitState,
             gradeState = gradeState,
             popularState = popularState,
             shouldShowFiltersBar = shouldShowFiltersBar,
+            offlineAreaDownloader = offlineAreaDownloader,
             onHideAreaName = onHideAreaName,
             onSearchBarClicked = onSearchBarClicked,
             onCircuitFilterChipClicked = onCircuitFilterChipClicked,
             onGradeFilterChipClicked = onGradeFilterChipClicked,
             onPopularFilterChipClicked = onPopularFilterChipClicked,
-            onResetFiltersClicked = onResetFiltersClicked
+            onResetFiltersClicked = onResetFiltersClicked,
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -83,7 +90,10 @@ fun MapControlsOverlay(
 private fun MapControlsOverlayPreview() {
     BoolderTheme {
         MapControlsOverlay(
-            areaName = "Apremont",
+            offlineAreaItem = OfflineAreaItem(
+                area = dummyArea(),
+                status = OfflineAreaItemStatus.NotDownloaded
+            ),
             circuitState = MapViewModel.CircuitState(
                 circuitId = 0,
                 color = CircuitColor.ORANGE,
@@ -95,6 +105,7 @@ private fun MapControlsOverlayPreview() {
             ),
             popularState = MapViewModel.PopularFilterState(isEnabled = false),
             shouldShowFiltersBar = true,
+            offlineAreaDownloader = dummyOfflineAreaDownloader(),
             onHideAreaName = {},
             onSearchBarClicked = {},
             onCircuitFilterChipClicked = {},

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/MapHeaderLayout.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/MapHeaderLayout.kt
@@ -30,16 +30,21 @@ import androidx.compose.ui.unit.dp
 import com.boolder.boolder.R
 import com.boolder.boolder.domain.model.ALL_GRADES
 import com.boolder.boolder.domain.model.CircuitColor
+import com.boolder.boolder.offline.OfflineAreaDownloader
+import com.boolder.boolder.offline.dummyOfflineAreaDownloader
+import com.boolder.boolder.utils.previewgenerator.dummyOfflineAreaItem
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.map.MapViewModel
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
 
 @Composable
 fun MapHeaderLayout(
-    areaName: String?,
+    offlineAreaItem: OfflineAreaItem?,
     circuitState: MapViewModel.CircuitState?,
     gradeState: MapViewModel.GradeState,
     popularState: MapViewModel.PopularFilterState,
     shouldShowFiltersBar: Boolean,
+    offlineAreaDownloader: OfflineAreaDownloader,
     onHideAreaName: () -> Unit,
     onSearchBarClicked: () -> Unit,
     onCircuitFilterChipClicked: () -> Unit,
@@ -56,7 +61,8 @@ fun MapHeaderLayout(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .padding(top = 16.dp),
-            areaName = areaName,
+            offlineAreaItem = offlineAreaItem,
+            offlineAreaDownloader = offlineAreaDownloader,
             onHideAreaName = onHideAreaName,
             onSearchBarClicked = onSearchBarClicked
         )
@@ -70,7 +76,7 @@ fun MapHeaderLayout(
                 circuitState = circuitState,
                 gradeState = gradeState,
                 popularState = popularState,
-                showCircuitFilterChip = areaName != null,
+                showCircuitFilterChip = offlineAreaItem != null,
                 onCircuitFilterChipClicked = onCircuitFilterChipClicked,
                 onGradeFilterChipClicked = onGradeFilterChipClicked,
                 onPopularFilterChipClicked = onPopularFilterChipClicked,
@@ -202,7 +208,7 @@ private fun MapFilterChip(
 private fun MapHeaderLayoutPreview() {
     BoolderTheme {
         MapHeaderLayout(
-            areaName = "Apremont",
+            offlineAreaItem = dummyOfflineAreaItem(),
             circuitState = MapViewModel.CircuitState(
                 circuitId = 42,
                 color = CircuitColor.BLUE,
@@ -214,6 +220,7 @@ private fun MapHeaderLayoutPreview() {
             ),
             popularState = MapViewModel.PopularFilterState(isEnabled = false),
             shouldShowFiltersBar = true,
+            offlineAreaDownloader = dummyOfflineAreaDownloader(),
             onHideAreaName = {},
             onSearchBarClicked = {},
             onCircuitFilterChipClicked = {},

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/MapTopBar.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/MapTopBar.kt
@@ -8,11 +8,16 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.viewinterop.AndroidViewBinding
 import com.boolder.boolder.databinding.SearchComponentBinding
+import com.boolder.boolder.offline.OfflineAreaDownloader
+import com.boolder.boolder.offline.dummyOfflineAreaDownloader
+import com.boolder.boolder.utils.previewgenerator.dummyOfflineAreaItem
 import com.boolder.boolder.view.compose.BoolderTheme
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
 
 @Composable
 fun MapTopBar(
-    areaName: String?,
+    offlineAreaItem: OfflineAreaItem?,
+    offlineAreaDownloader: OfflineAreaDownloader,
     onHideAreaName: () -> Unit,
     onSearchBarClicked: () -> Unit,
     modifier: Modifier = Modifier
@@ -33,8 +38,9 @@ fun MapTopBar(
         )
 
         AreaName(
-            name = areaName,
-            onHideAreaName = onHideAreaName
+            offlineAreaItem = offlineAreaItem,
+            offlineAreaDownloader = offlineAreaDownloader,
+            onHideAreaName = onHideAreaName,
         )
     }
 }
@@ -43,17 +49,18 @@ fun MapTopBar(
 @Composable
 private fun MapTopBarPreview(
     @PreviewParameter(MapTopBarParameterPreviewProvider::class)
-    areaName: String?
+    offlineAreaItem: OfflineAreaItem?
 ) {
     BoolderTheme {
         MapTopBar(
-            areaName = areaName,
+            offlineAreaItem = offlineAreaItem,
+            offlineAreaDownloader = dummyOfflineAreaDownloader(),
             onHideAreaName = {},
             onSearchBarClicked = {}
         )
     }
 }
 
-private class MapTopBarParameterPreviewProvider : PreviewParameterProvider<String?> {
-    override val values = sequenceOf(null, "Apremont")
+private class MapTopBarParameterPreviewProvider : PreviewParameterProvider<OfflineAreaItem?> {
+    override val values = sequenceOf(null, dummyOfflineAreaItem())
 }

--- a/app/src/main/java/com/boolder/boolder/view/offlinephotos/OfflinePhotosActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/offlinephotos/OfflinePhotosActivity.kt
@@ -1,0 +1,32 @@
+package com.boolder.boolder.view.offlinephotos
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.boolder.boolder.view.compose.BoolderTheme
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class OfflinePhotosActivity : AppCompatActivity() {
+
+    private val viewModel by viewModel<OfflinePhotosViewModel>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            BoolderTheme {
+                val screenState by viewModel.screenState.collectAsStateWithLifecycle()
+
+                OfflinePhotosScreen(
+                    screenState = screenState,
+                    onDownloadAreaClicked = viewModel::onDownloadAreaClicked,
+                    onDownloadTerminated = viewModel::onDownloadTerminated,
+                    onCancelDownload = viewModel::onCancelDownload,
+                    onDeleteAreaClicked = viewModel::onDeleteAreaClicked
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/view/offlinephotos/OfflinePhotosScreen.kt
+++ b/app/src/main/java/com/boolder/boolder/view/offlinephotos/OfflinePhotosScreen.kt
@@ -1,0 +1,170 @@
+package com.boolder.boolder.view.offlinephotos
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.boolder.boolder.domain.model.Area
+import com.boolder.boolder.view.compose.BoolderTheme
+import com.boolder.boolder.view.offlinephotos.composable.OfflinePhotosAreaItem
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
+
+@Composable
+fun OfflinePhotosScreen(
+    screenState: OfflinePhotosViewModel.ScreenState,
+    onDownloadAreaClicked: (Int) -> Unit,
+    onDownloadTerminated: (Int) -> Unit,
+    onCancelDownload: (Int) -> Unit,
+    onDeleteAreaClicked: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val internalModifier = modifier
+        .fillMaxSize()
+        .background(color = Color.White)
+
+    if (screenState.items.isEmpty()) {
+        OfflinePhotosScreenLoading(modifier = internalModifier)
+    } else {
+        OfflinePhotosScreenContent(
+            modifier = internalModifier,
+            screenState = screenState,
+            onDownloadAreaClicked = onDownloadAreaClicked,
+            onDownloadTerminated = onDownloadTerminated,
+            onCancelDownload = onCancelDownload,
+            onDeleteAreaClicked = onDeleteAreaClicked
+        )
+    }
+}
+
+@Composable
+private fun OfflinePhotosScreenLoading(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.systemBarsPadding(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun OfflinePhotosScreenContent(
+    screenState: OfflinePhotosViewModel.ScreenState,
+    onDownloadAreaClicked: (Int) -> Unit,
+    onDownloadTerminated: (Int) -> Unit,
+    onCancelDownload: (Int) -> Unit,
+    onDeleteAreaClicked: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val systemBarsInsets = WindowInsets.systemBars.asPaddingValues()
+
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = PaddingValues(
+            start = 16.dp,
+            top = systemBarsInsets.calculateTopPadding() + 16.dp,
+            end = 16.dp,
+            bottom = systemBarsInsets.calculateBottomPadding() + 16.dp
+        ),
+        verticalArrangement = spacedBy(16.dp)
+    ) {
+        items(
+            items = screenState.items,
+            key = { it.area.id }
+        ) {
+            OfflinePhotosAreaItem(
+                areaName = it.area.name,
+                status = it.status,
+                onDownloadClicked = { onDownloadAreaClicked(it.area.id) },
+                onDownloadTerminated = { onDownloadTerminated(it.area.id) },
+                onCancelDownload = { onCancelDownload(it.area.id) },
+                onDeleteClicked = { onDeleteAreaClicked(it.area.id) }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OfflinePhotosScreenPreview(
+    @PreviewParameter(OfflinePhotosScreenPreviewParameterProvider::class)
+    screenState: OfflinePhotosViewModel.ScreenState
+) {
+    BoolderTheme {
+        OfflinePhotosScreen(
+            modifier = Modifier.background(color = Color.White),
+            screenState = screenState,
+            onDownloadAreaClicked = {},
+            onDownloadTerminated = {},
+            onCancelDownload = {},
+            onDeleteAreaClicked = {}
+        )
+    }
+}
+
+private class OfflinePhotosScreenPreviewParameterProvider :
+    PreviewParameterProvider<OfflinePhotosViewModel.ScreenState> {
+
+    private val content = OfflinePhotosViewModel.ScreenState(
+        items = listOf(
+            area(16, "91.1"),
+            area(10, "95.2"),
+            area(7, "Apremont"),
+            area(46, "Apremont Bizons"),
+            area(48, "Apremont Butte aux Dames"),
+            area(63, "Apremont Désert"),
+            area(62, "Apremont Envers"),
+            area(69, "Apremont Est"),
+            area(20, "Apremont Ouest"),
+            area(49, "Apremont Solitude"),
+            area(29, "Beauvais Nainville"),
+            area(21, "Bois Rond"),
+            area(78, "Buthiers Canard"),
+            area(23, "Buthiers Piscine"),
+            area(77, "Buthiers Tennis"),
+            area(13, "Canche aux Merciers")
+        ).mapIndexed { index, area ->
+            OfflineAreaItem(
+                area = area,
+                status = when {
+                    index < 4 -> OfflineAreaItemStatus.Downloaded(folderSize = "50 MB")
+                    index < 5 -> OfflineAreaItemStatus.Downloading(areaId = 48)
+                    else -> OfflineAreaItemStatus.NotDownloaded
+                }
+            )
+        }
+    )
+
+    private fun area(id: Int, name: String) = Area(
+        id = id,
+        name = name,
+        southWestLat = 0f,
+        southWestLon = 0f,
+        northEastLat = 0f,
+        northEastLon = 0f
+    )
+
+    override val values = sequenceOf(
+        OfflinePhotosViewModel.ScreenState(items = emptyList()),
+        content
+    )
+
+}

--- a/app/src/main/java/com/boolder/boolder/view/offlinephotos/OfflinePhotosViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/offlinephotos/OfflinePhotosViewModel.kt
@@ -1,0 +1,95 @@
+package com.boolder.boolder.view.offlinephotos
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.boolder.boolder.data.database.repository.AreaRepository
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
+import com.boolder.boolder.offline.BoolderOfflineRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+abstract class OfflinePhotosViewModel : ViewModel() {
+    abstract val screenState: StateFlow<ScreenState>
+
+    abstract fun onDownloadAreaClicked(areaId: Int)
+    abstract fun onDownloadTerminated(areaId: Int)
+    abstract fun onCancelDownload(areaId: Int)
+    abstract fun onDeleteAreaClicked(areaId: Int)
+
+    data class ScreenState(val items: List<OfflineAreaItem> = emptyList())
+}
+
+class OfflinePhotosViewModelImpl(
+    private val areaRepository: AreaRepository,
+    private val boolderOfflineRepository: BoolderOfflineRepository
+) : OfflinePhotosViewModel() {
+
+    override val screenState = MutableStateFlow(ScreenState())
+
+    init {
+        viewModelScope.launch {
+            val items = areaRepository.getAllAreas()
+                .map { area ->
+                    OfflineAreaItem(
+                        area = area,
+                        status = boolderOfflineRepository.getStatusForAreaId(area.id)
+                    )
+                }
+
+            val content = ScreenState(items = items)
+
+            screenState.emit(content)
+        }
+    }
+
+    override fun onDownloadAreaClicked(areaId: Int) {
+        updateItemToDownloadingState(areaId)
+        boolderOfflineRepository.downloadArea(areaId)
+    }
+
+    override fun onDownloadTerminated(areaId: Int) {
+        updateItems(areaId)
+    }
+
+    override fun onCancelDownload(areaId: Int) {
+        boolderOfflineRepository.cancelAreaDownload(areaId)
+        onDeleteAreaClicked(areaId)
+    }
+
+    override fun onDeleteAreaClicked(areaId: Int) {
+        boolderOfflineRepository.deleteArea(areaId)
+        updateItems(areaId)
+    }
+
+    private fun updateItemToDownloadingState(areaId: Int) {
+        val newItems = screenState.value.items.map { item ->
+            if (item.area.id == areaId) {
+                item.copy(
+                    status = OfflineAreaItemStatus.Downloading(areaId = areaId)
+                )
+            } else {
+                item
+            }
+        }
+
+        screenState.update { it.copy(items = newItems) }
+    }
+
+    private fun updateItems(areaId: Int) {
+        val newItems = screenState.value.items.map { item ->
+            if (item.area.id == areaId) {
+                item.copy(
+                    area = item.area,
+                    status = boolderOfflineRepository.getStatusForAreaId(item.area.id)
+                )
+            } else {
+                item
+            }
+        }
+
+        screenState.update { it.copy(items = newItems) }
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/view/offlinephotos/composable/OfflinePhotosAreaItem.kt
+++ b/app/src/main/java/com/boolder/boolder/view/offlinephotos/composable/OfflinePhotosAreaItem.kt
@@ -1,0 +1,312 @@
+package com.boolder.boolder.view.offlinephotos.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.boolder.boolder.R
+import com.boolder.boolder.view.compose.BoolderTheme
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
+import com.boolder.boolder.offline.DOWNLOAD_TERMINATED_STATUSES
+import com.boolder.boolder.offline.WORK_DATA_PROGRESS
+import com.boolder.boolder.offline.WORK_DATA_PROGRESS_DETAIL
+import com.boolder.boolder.offline.getDownloadTopoImagesWorkName
+
+@Composable
+fun OfflinePhotosAreaItem(
+    areaName: String,
+    status: OfflineAreaItemStatus,
+    onDownloadClicked: () -> Unit,
+    onDownloadTerminated: () -> Unit,
+    onCancelDownload: () -> Unit,
+    onDeleteClicked: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val shape = RoundedCornerShape(8.dp)
+    val internalModifier = modifier
+        .fillMaxWidth()
+        .height(56.dp)
+        .clip(shape)
+        .border(width = 1.dp, color = Color.Gray, shape = shape)
+
+    when (status) {
+        is OfflineAreaItemStatus.NotDownloaded -> OfflinePhotosAreaNotDownloadedItem(
+            modifier = internalModifier,
+            areaName = areaName,
+            onDownloadClicked = onDownloadClicked
+        )
+
+        is OfflineAreaItemStatus.Downloading -> OfflinePhotosAreaDownloadingItem(
+            modifier = internalModifier,
+            areaName = areaName,
+            areaId = status.areaId,
+            onDownloadTerminated = onDownloadTerminated,
+            onCancelDownload = onCancelDownload
+        )
+
+        is OfflineAreaItemStatus.Downloaded -> OfflinePhotosAreaDownloadedItem(
+            modifier = internalModifier,
+            areaName = areaName,
+            folderSize = status.folderSize,
+            onDeleteClicked = onDeleteClicked
+        )
+    }
+}
+
+@Composable
+private fun OfflinePhotosAreaNotDownloadedItem(
+    areaName: String,
+    onDownloadClicked: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.padding(8.dp),
+        horizontalArrangement = Arrangement.Absolute.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AreaName(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 8.dp),
+            areaName = areaName
+        )
+
+        Icon(
+            modifier = Modifier
+                .clip(CircleShape)
+                .clickable(onClick = onDownloadClicked)
+                .padding(8.dp),
+            painter = painterResource(id = R.drawable.ic_download_for_offline),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+    }
+}
+
+@Composable
+private fun OfflinePhotosAreaDownloadingItem(
+    areaName: String,
+    areaId: Int,
+    onDownloadTerminated: () -> Unit,
+    onCancelDownload: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    BoxWithConstraints(
+        modifier = modifier,
+        contentAlignment = Alignment.CenterStart
+    ) {
+        val progressModifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+
+        if (LocalInspectionMode.current) {
+            Box(
+                modifier = progressModifier
+                    .graphicsLayer {
+                        transformOrigin = TransformOrigin(0f, 0f)
+                        scaleX = .4f
+                    }
+                    .background(color = Color.Gray.copy(alpha = .3f))
+            )
+
+            OfflinePhotosAreaDownloadingItemContent(
+                areaName = areaName,
+                progressDetail = "4/10",
+                onCancelDownload = {}
+            )
+        } else {
+            val workInfoList by WorkManager.getInstance(LocalContext.current)
+                .getWorkInfosForUniqueWorkLiveData(areaId.getDownloadTopoImagesWorkName())
+                .observeAsState()
+
+            if (workInfoList?.all { it.state in DOWNLOAD_TERMINATED_STATUSES } == true) {
+                onDownloadTerminated()
+            }
+
+            val workInfo = workInfoList
+                ?.firstOrNull { it.state == WorkInfo.State.RUNNING }
+                ?: return@BoxWithConstraints
+
+            val progress = workInfo.progress
+                .getFloat(WORK_DATA_PROGRESS, 0f)
+
+            Box(
+                modifier = progressModifier
+                    .graphicsLayer {
+                        transformOrigin = TransformOrigin(0f, 0f)
+                        scaleX = progress
+                    }
+                    .background(color = Color.Gray.copy(alpha = .3f))
+            )
+
+            val progressDetail = workInfo.progress
+                .getString(WORK_DATA_PROGRESS_DETAIL)
+
+            OfflinePhotosAreaDownloadingItemContent(
+                areaName = areaName,
+                progressDetail = progressDetail,
+                onCancelDownload = onCancelDownload
+            )
+        }
+    }
+}
+
+@Composable
+private fun OfflinePhotosAreaDownloadingItemContent(
+    areaName: String,
+    progressDetail: String?,
+    onCancelDownload: () -> Unit
+) {
+    Row(
+        modifier = Modifier.padding(8.dp),
+        horizontalArrangement = Arrangement.Absolute.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .size(24.dp)
+        )
+
+        AreaName(
+            modifier = Modifier.weight(1f),
+            areaName = areaName
+        )
+
+        if (!progressDetail.isNullOrEmpty()) {
+            Text(
+                text = "($progressDetail)",
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+
+        Icon(
+            modifier = Modifier
+                .clip(CircleShape)
+                .clickable(onClick = onCancelDownload)
+                .padding(8.dp),
+            painter = painterResource(id = R.drawable.ic_cancel),
+            contentDescription = null,
+            tint = Color.Gray
+        )
+    }
+}
+
+@Composable
+private fun OfflinePhotosAreaDownloadedItem(
+    areaName: String,
+    folderSize: String,
+    onDeleteClicked: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.padding(8.dp),
+        horizontalArrangement = Arrangement.Absolute.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .size(24.dp),
+            painter = painterResource(id = R.drawable.ic_download_done),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+
+        AreaName(
+            modifier = Modifier.weight(1f),
+            areaName = areaName
+        )
+
+        Text(
+            text = "($folderSize)",
+            style = MaterialTheme.typography.bodySmall
+        )
+
+        Icon(
+            modifier = Modifier
+                .clip(CircleShape)
+                .clickable(onClick = onDeleteClicked)
+                .padding(8.dp),
+            painter = painterResource(id = R.drawable.ic_delete_forever),
+            contentDescription = null,
+            tint = Color.Gray
+        )
+    }
+}
+
+@Composable
+private fun AreaName(
+    areaName: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        modifier = modifier,
+        text = areaName,
+        style = MaterialTheme.typography.bodyMedium,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+@Preview
+@Composable
+private fun OfflinePhotosAreaItemPreview(
+    @PreviewParameter(OfflinePhotosAreaItemPreviewParameterProvider::class)
+    status: OfflineAreaItemStatus
+) {
+    BoolderTheme {
+        OfflinePhotosAreaItem(
+            modifier = Modifier
+                .background(color = Color.White)
+                .padding(16.dp),
+            areaName = "Apremont",
+            status = status,
+            onDownloadClicked = {},
+            onDownloadTerminated = {},
+            onCancelDownload = {},
+            onDeleteClicked = {}
+        )
+    }
+}
+
+private class OfflinePhotosAreaItemPreviewParameterProvider :
+    PreviewParameterProvider<OfflineAreaItemStatus> {
+    override val values = sequenceOf(
+        OfflineAreaItemStatus.NotDownloaded,
+        OfflineAreaItemStatus.Downloading(areaId = 7),
+        OfflineAreaItemStatus.Downloaded(folderSize = "50 MB"),
+    )
+}

--- a/app/src/main/java/com/boolder/boolder/view/offlinephotos/model/OfflineAreaItem.kt
+++ b/app/src/main/java/com/boolder/boolder/view/offlinephotos/model/OfflineAreaItem.kt
@@ -1,0 +1,14 @@
+package com.boolder.boolder.view.offlinephotos.model
+
+import com.boolder.boolder.domain.model.Area
+
+data class OfflineAreaItem(
+    val area: Area,
+    val status: OfflineAreaItemStatus
+)
+
+sealed interface OfflineAreaItemStatus {
+    data object NotDownloaded : OfflineAreaItemStatus
+    data class Downloaded(val folderSize: String) : OfflineAreaItemStatus
+    data class Downloading(val areaId: Int) : OfflineAreaItemStatus
+}

--- a/app/src/main/res/drawable/ic_delete_forever.xml
+++ b/app/src/main/res/drawable/ic_delete_forever.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M14.12,10.47L12,12.59l-2.13,-2.12 -1.41,1.41L10.59,14l-2.12,2.12 1.41,1.41L12,15.41l2.12,2.12 1.41,-1.41L13.41,14l2.12,-2.12zM15.5,4l-1,-1h-5l-1,1H5v2h14V4zM6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM8,9h8v10H8V9z" />
+</vector>

--- a/app/src/main/res/drawable/ic_download_done.xml
+++ b/app/src/main/res/drawable/ic_download_done.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M5,18h14v2L5,20v-2zM9.6,15.3L5,10.7l2,-1.9 2.6,2.6L17,4l2,2 -9.4,9.3z" />
+</vector>

--- a/app/src/main/res/drawable/ic_download_for_offline.xml
+++ b/app/src/main/res/drawable/ic_download_for_offline.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.49,2 2,6.49 2,12s4.49,10 10,10s10,-4.49 10,-10S17.51,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8s8,3.59 8,8S16.41,20 12,20zM14.59,8.59L16,10l-4,4l-4,-4l1.41,-1.41L11,10.17V6h2v4.17L14.59,8.59zM17,17H7v-2h10V17z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,6 +13,16 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 
+<!--        <Button-->
+<!--            android:id="@+id/offline_photos_button"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_marginEnd="16dp"-->
+<!--            android:layout_marginBottom="16dp"-->
+<!--            android:text="Offline photos"-->
+<!--            app:layout_constraintBottom_toTopOf="@+id/fab_location"-->
+<!--            app:layout_constraintEnd_toEndOf="parent" />-->
+
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab_location"
             android:layout_width="wrap_content"


### PR DESCRIPTION
In order to have a decent user experience in areas where the mobile network coverage is not good, the user should be able to download the photos by advance and persist them on the device.

https://github.com/boolder-org/boolder-android/assets/8343416/8fde32c0-c132-4eaa-b64b-48adb8ddf467

This commit also adds an activity that shows the download state of all the areas. For now, it will be used for debugging purposes, and will not be accessible to the users.
