### PR TITLE
Disable MapBox telemetry

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
@@ -43,10 +43,12 @@ import com.mapbox.maps.extension.style.layers.generated.LineLayer
 import com.mapbox.maps.extension.style.layers.generated.SymbolLayer
 import com.mapbox.maps.extension.style.layers.getLayerAs
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
+import com.mapbox.maps.plugin.Plugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.animation.easeTo
 import com.mapbox.maps.plugin.animation.flyTo
+import com.mapbox.maps.plugin.attribution.AttributionPlugin
 import com.mapbox.maps.plugin.compass.compass
 import com.mapbox.maps.plugin.gestures.addOnMapClickListener
 import com.mapbox.maps.plugin.gestures.gestures
@@ -106,6 +108,15 @@ class BoolderMap @JvmOverloads constructor(
 
     fun setup(listener: BoolderMapListener, buildStyle: StyleExtension) {
         this.listener = listener
+
+        getPlugin<AttributionPlugin>(Plugin.MAPBOX_ATTRIBUTION_PLUGIN_ID)
+            ?.getMapAttributionDelegate()
+            ?.telemetry()
+            ?.apply {
+                disableTelemetrySession()
+                userTelemetryRequestState = false
+            }
+
         getMapboxMap().loadStyle(buildStyle)
     }
 

--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -116,7 +116,7 @@ class MapFragment : Fragment(), BoolderMapListener {
             })
         }
 
-        setupMap()
+        binding.mapView.setup(this, layerFactory.buildStyle())
 
         binding.fabLocation.setOnClickListener {
             locationProvider.askForPosition()
@@ -235,10 +235,6 @@ class MapFragment : Fragment(), BoolderMapListener {
             enabled = true
             pulsingEnabled = true
         }
-    }
-
-    private fun setupMap() {
-        binding?.mapView?.setup(this, layerFactory.buildStyle())
     }
 
     // Triggered when user click on a Problem on Map


### PR DESCRIPTION
The new release is blocked by the Google Play User Data policy with the following message:
```
Issue details

We found an issue in the following area(s):

Version code 17: Policy Declaration - Data Safety Section: Location Data Type - Precise Location
```

I suspect the MapBox SDK to track the user's location with the telemetry (that seems to be enabled by default), so let's try disabling it in order to avoid triggering the issue on the Google Play's side