### PR TITLE
Keep mapbox access token private from source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ Here is a 15-min video describing the architecture of the app : https://youtu.be
 Create a file named `gradle.properties` in the `~/.gradle/` directory, with the following content:
 
 ```
-MAPBOX_DOWNLOADS_TOKEN={TOKEN}
+MAPBOX_ACCESS_TOKEN={ACCESS_TOKEN}
+MAPBOX_DOWNLOADS_TOKEN={DOWNLOADS_TOKEN}
 ```
 
-Replace `{TOKEN}` with mapbox secret key.
+Replace respectively `{ACCESS_TOKEN}` and `{DOWNLOADS_TOKEN}` with the mapbox default public token
+and the secret download key.
 
 More info [here](https://docs.mapbox.com/help/troubleshooting/private-access-token-android-and-ios/).
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,12 @@ android {
         versionName = "1.16" // bump when new version
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        resValue(
+            type = "string",
+            name = "mapbox_access_token",
+            value = providers.gradleProperty("MAPBOX_ACCESS_TOKEN").get()
+        )
     }
 
     buildTypes {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name" translatable="false">Boolder</string>
-    <string name="mapbox_access_token" translatable="false">pk.eyJ1Ijoibm1vbmRvbGxvdCIsImEiOiJjbGI4MzkwaTgwaGUwM3RsanVwaDV1ODdxIn0.65x8Cd14jj4vV4EOrC9SMw</string>
 
     <string name="search_query_hint">Problem or area name</string>
     <string name="cd_find_my_position">Find my position</string>


### PR DESCRIPTION
The mapbox access token was publicly accessible in the source files of the app, and could be easily used by other individuals or projects. This commit changes the way it is accessed and reads it from the user's `gradle.properties` file.

Resolves #71 