### PR TITLE
Fix compose BOM version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.boolder.boolder"
         minSdk = 21
         targetSdk = 34
-        versionCode = 22 // bump when new version
-        versionName = "1.17" // bump when new version
+        versionCode = 23 // bump when new version
+        versionName = "1.17.1" // bump when new version
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -87,7 +87,7 @@ dependencies {
     implementation("io.coil-kt:coil:2.5.0")
 
     // Jetpack compose
-    val composeBom = platform("androidx.compose:compose-bom:2024.01.00")
+    val composeBom = platform("androidx.compose:compose-bom:2023.10.01")
     implementation(composeBom)
     androidTestImplementation(composeBom)
     implementation("androidx.compose.material3:material3")


### PR DESCRIPTION
The latest Jetpack compose BOM version makes the app crashing on the Area overview screen. This commit rolls this version back to the last stable one.