### PR TITLE
Display the topo bottom sheet over the bottom nav bar

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/detail/TopoView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/TopoView.kt
@@ -16,8 +16,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.Insets
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
+import androidx.core.view.updateLayoutParams
 import coil.load
 import com.boolder.boolder.R
 import com.boolder.boolder.databinding.ViewTopoBinding
@@ -70,6 +72,10 @@ class TopoView(
         updateCircuitControls(circuitInfo = topo.circuitInfo)
 
         topo.selectedCompleteProblem?.let { updateFooter(it.problemWithLine.problem) }
+    }
+
+    fun applyInsets(insets: Insets) {
+        binding.bottomInsetSpace.updateLayoutParams { height = insets.bottom }
     }
 
     private fun onProblemPictureLoaded(topo: Topo) {

--- a/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverScreen.kt
+++ b/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -27,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush.Companion.verticalGradient
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -53,7 +55,9 @@ internal fun DiscoverScreen(
     modifier: Modifier = Modifier
 ) {
     Scaffold(
-        modifier = modifier,
+        modifier = modifier
+            .padding(bottom = dimensionResource(id = R.dimen.height_bottom_nav_bar))
+            .navigationBarsPadding(),
         topBar = {
             TopAppBar(
                 title = {

--- a/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
@@ -6,6 +6,8 @@ import android.util.Log
 import android.util.TypedValue
 import android.view.Gravity
 import androidx.core.graphics.Insets
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updateMargins
 import com.boolder.boolder.R
 import com.boolder.boolder.domain.model.BoolderMapConfig
 import com.boolder.boolder.domain.model.Circuit
@@ -88,10 +90,13 @@ class BoolderMap @JvmOverloads constructor(
         gestures.pitchEnabled = false
         scalebar.enabled = false
         compass.updateSettings {
+            val compassMargin = resources.getDimension(R.dimen.margin_map_controls)
+
             visibility = true
             position = Gravity.BOTTOM or Gravity.START
-            marginLeft = resources.getDimension(R.dimen.margin_map_controls)
-            marginRight = resources.getDimension(R.dimen.margin_map_controls)
+            marginLeft = compassMargin
+            marginRight = compassMargin
+            marginBottom = compassMargin
         }
         addClickEvent()
 
@@ -439,7 +444,11 @@ class BoolderMap @JvmOverloads constructor(
     fun applyInsets(insets: Insets) {
         this.insets = insets
 
-        compass.marginBottom = resources.getDimension(R.dimen.margin_map_controls) + insets.bottom
+        val bottomNavHeight = resources.getDimensionPixelSize(R.dimen.height_bottom_nav_bar)
+
+        updateLayoutParams<MarginLayoutParams> {
+            updateMargins(bottom = insets.bottom + bottomNavHeight)
+        }
     }
 
     fun onCircuitSelected(circuit: Circuit) {

--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.Button
 import android.widget.FrameLayout
@@ -15,6 +16,8 @@ import android.widget.TextView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.postDelayed
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updateMargins
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.boolder.boolder.R
@@ -90,6 +93,13 @@ class MapFragment : Fragment(), BoolderMapListener {
             val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
 
             binding.mapView.applyInsets(systemInsets)
+            binding.fabLocation.updateLayoutParams<MarginLayoutParams> {
+                val bottomMargin = resources.getDimensionPixelSize(R.dimen.margin_map_controls)
+                val bottomNavHeight = resources.getDimensionPixelSize(R.dimen.height_bottom_nav_bar)
+
+                updateMargins(bottom = bottomMargin + systemInsets.bottom + bottomNavHeight)
+            }
+            binding.topoView.applyInsets(systemInsets)
 
             insets
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,29 +4,29 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_navigation_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        app:elevation="0dp"
+        app:itemIconTint="@color/bottom_nav_item_color"
+        app:itemTextColor="@color/bottom_nav_item_color"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:menu="@menu/menu_bottom_nav" />
+
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:defaultNavHost="true"
-        app:layout_constraintBottom_toTopOf="@+id/bottom_navigation_view"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:navGraph="@navigation/nav_graph" />
-
-    <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottom_navigation_view"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:background="@color/white"
-        app:itemIconTint="@color/bottom_nav_item_color"
-        app:itemTextColor="@color/bottom_nav_item_color"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/nav_host_fragment"
-        app:menu="@menu/menu_bottom_nav" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <dimen name="height_bottom_nav_bar">80dp</dimen>
+
     <dimen name="margin_search_component">16dp</dimen>
     <dimen name="margin_map_controls">20dp</dimen>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,14 +1,13 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="Theme.Boolder" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.Boolder" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/primary</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/primary</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
+        <item name="colorSecondaryContainer">#E6E6E6</item>
 
         <!-- Customize your theme here. -->
         <item name="android:windowActivityTransitions">true</item>


### PR DESCRIPTION
The topo bottom sheet was displayed above the bottom navigation bar, which was taking more vertical space than before having the bottom navigation bar in the app. This commit makes the topo bottom sheet being displayed from the bottom of the screen, over the bottom navigation bar.

|Before|After|
|-|-|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/25b0d1df-59bf-4a2a-ba07-f59386b5938d" width=400 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/f7a04dd4-1f96-43fd-af87-6e4ed26074a5" width=400 />|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/762b99c8-e3e0-4638-89f7-2e9fc7db4bc5" width=400 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/880b7cbb-7318-4a4f-8e13-5d14caee0359" width=400 />|

The XML theme has also been updated to Material Design 3, in order to be aligned with the Compose elements that are already using Material Design 3 components. These changes are visible in the bottom navigation bar and the floating action button.
