### PR TITLE
Fix circuit start button padding

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -13,6 +13,9 @@ import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.TextView
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.postDelayed
@@ -145,6 +148,9 @@ class MapFragment : Fragment(), BoolderMapListener {
             binding.controlsOverlayComposeView.setContent {
                 BoolderTheme {
                     MapControlsOverlay(
+                        modifier = Modifier.padding(
+                            bottom = dimensionResource(id = R.dimen.height_bottom_nav_bar)
+                        ),
                         offlineAreaItem = screenState.areaState,
                         circuitState = screenState.circuitState,
                         gradeState = screenState.gradeState,


### PR DESCRIPTION
Following the adaptation of the topo bottom sheet to be displayed above the bottom navigation bar, the circuit start button was also displayed above the bottom navigation bar.

|Before|After|
|-|-|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/fd618e56-96bf-42c2-a3f4-8c710816215a" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/85eb4c67-7f60-4438-bedd-9f371dd0b0ab" width=300 />|
