### PR TITLE
Fix `LocationProvider` crash

### DIFF
--- a/app/src/main/java/com/boolder/boolder/utils/LocationProvider.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/LocationProvider.kt
@@ -99,8 +99,8 @@ class LocationProvider(private val activity: FragmentActivity) {
         fusedLocationClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, object : CancellationToken() {
             override fun onCanceledRequested(p0: OnTokenCanceledListener) = CancellationTokenSource().token
             override fun isCancellationRequested() = false
-        }).addOnSuccessListener {
-            _locationFlow.tryEmit(it)
+        }).addOnSuccessListener { location ->
+            location?.let(_locationFlow::tryEmit)
             isWaitingPosition = false
         }
     }


### PR DESCRIPTION
The following crash was reported in the Google Play console:
```
Exception java.lang.NullPointerException:
  at com.boolder.boolder.utils.LocationProvider$moveCameraToUserPosition$2.invoke (LocationProvider.kt:103)
  at com.boolder.boolder.utils.LocationProvider$moveCameraToUserPosition$2.invoke (LocationProvider.kt:102)
  at com.boolder.boolder.utils.LocationProvider.moveCameraToUserPosition$lambda$4 (LocationProvider.kt:102)
  at com.boolder.boolder.utils.LocationProvider.$r8$lambda$l0fe5LEIV0faGWNGvz3WtHbTFgA
  at com.boolder.boolder.utils.LocationProvider$$ExternalSyntheticLambda2.onSuccess
  at com.google.android.gms.tasks.zzm.run (com.google.android.gms:play-services-tasks@@18.0.2:1)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8893)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:608)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
  ```
  
It happens that the `Location` that is returned by the location listener's success callback can be `null` in some cases (without any warning from the Kotlin compiler as the subsequent location API is written in Java), so the fix resides in checking the result before emitting it in the location flow.
