### PR TITLE
Update Android Gradle plugin to version 8.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.2.2' apply false
-    id 'com.android.library' version '8.2.2' apply false
+    id 'com.android.application' version '8.3.0' apply false
+    id 'com.android.library' version '8.3.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.21' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.21' apply false
     id 'com.google.devtools.ksp' version "1.9.21-1.0.16" apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,4 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 android.enableR8.fullMode=false
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Nov 16 11:09:40 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
A new version of android studio (Iguana) is available, therefore a new version of AGP (Android Gradle Plugin).
This commit updates AGP to the version `8.3.0`.