### PR TITLE
Add projects and ticked problems filters

### DIFF
--- a/app/src/main/java/com/boolder/boolder/data/userdatabase/dao/TickedProblemDao.kt
+++ b/app/src/main/java/com/boolder/boolder/data/userdatabase/dao/TickedProblemDao.kt
@@ -12,6 +12,9 @@ interface TickedProblemDao {
     @Query("SELECT * FROM ticked_problems")
     suspend fun getAllTickedProblems(): List<TickedProblemEntity>
 
+    @Query("SELECT problem_id FROM ticked_problems WHERE tick_status = :tickStatus")
+    suspend fun getSavedProblemIds(tickStatus: String): List<Int>
+
     @Query("SELECT * FROM ticked_problems WHERE problem_id = :problemId")
     suspend fun getTickedProblemByProblemId(problemId: Int): TickedProblemEntity?
 

--- a/app/src/main/java/com/boolder/boolder/data/userdatabase/repository/TickedProblemRepository.kt
+++ b/app/src/main/java/com/boolder/boolder/data/userdatabase/repository/TickedProblemRepository.kt
@@ -1,6 +1,7 @@
 package com.boolder.boolder.data.userdatabase.repository
 
 import com.boolder.boolder.data.userdatabase.dao.TickedProblemDao
+import com.boolder.boolder.data.userdatabase.entity.TickStatus
 import com.boolder.boolder.domain.convert
 import com.boolder.boolder.domain.model.TickedProblem
 
@@ -14,6 +15,12 @@ class TickedProblemRepository(
 
     suspend fun getAllTickedProblems(): List<TickedProblem> =
         tickedProblemDao.getAllTickedProblems().map { it.convert() }
+
+    suspend fun getAllProjectIds(): List<Int> =
+        tickedProblemDao.getSavedProblemIds(tickStatus = TickStatus.PROJECT.name)
+
+    suspend fun getAllTickedProblemIds(): List<Int> =
+        tickedProblemDao.getSavedProblemIds(tickStatus = TickStatus.SUCCEEDED.name)
 
     suspend fun getTickedProblemByProblemId(problemId: Int): TickedProblem? =
         tickedProblemDao.getTickedProblemByProblemId(problemId)?.convert()

--- a/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
@@ -460,12 +460,18 @@ class BoolderMap @JvmOverloads constructor(
 
     fun applyFilters(
         grades: List<String>,
-        showPopular: Boolean
+        showPopular: Boolean,
+        projectIds: List<Int>,
+        tickedIds: List<Int>
     ) {
         val problemsLayer = getLayerAs<CircleLayer>(LAYER_PROBLEMS)
         val problemsTextLayer = getLayerAs<SymbolLayer>(LAYER_PROBLEMS_TEXT)
+
         val popularLayer = getLayerAs<SymbolLayer>(LAYER_PROBLEMS_NAMES)
         val popularAntiOverlapLayer = getLayerAs<SymbolLayer>(LAYER_PROBLEMS_NAMES_ANTI_OVERLAP)
+
+        val showProjects = projectIds.isNotEmpty()
+        val showTicked = tickedIds.isNotEmpty()
 
         val query = all {
             match {
@@ -476,6 +482,20 @@ class BoolderMap @JvmOverloads constructor(
             }
 
             if (showPopular) get("featured")
+
+            if (showProjects) {
+                inExpression {
+                    get("id")
+                    literal(projectIds)
+                }
+            }
+
+            if (showTicked) {
+                inExpression {
+                    get("id")
+                    literal(tickedIds)
+                }
+            }
         }
 
         problemsLayer?.filter(query)
@@ -483,7 +503,13 @@ class BoolderMap @JvmOverloads constructor(
 
         fun SymbolLayer.update() = apply {
             filter(query)
-            visibility(if (showPopular) Visibility.VISIBLE else Visibility.NONE)
+            visibility(
+                if (showPopular || showProjects || showTicked) {
+                    Visibility.VISIBLE
+                } else {
+                    Visibility.NONE
+                }
+            )
         }
 
         popularLayer?.update()

--- a/app/src/main/java/com/boolder/boolder/view/map/MapViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapViewModel.kt
@@ -266,7 +266,9 @@ class MapViewModel(
                     gradeRangeButtonTitle = resources.getString(R.string.grades),
                     grades = ALL_GRADES
                 ),
-                popularFilterState = PopularFilterState(isEnabled = false)
+                popularFilterState = PopularFilterState(isEnabled = false),
+                projectsFilterState = ProjectsFilterState(projectIds = emptyList()),
+                tickedFilterState = TickedFilterState(tickedProblemIds = emptyList())
             )
         }
     }

--- a/app/src/main/java/com/boolder/boolder/view/map/MapViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapViewModel.kt
@@ -20,6 +20,7 @@ import com.boolder.boolder.domain.model.TopoOrigin
 import com.boolder.boolder.domain.model.gradeRangeLevelDisplay
 import com.boolder.boolder.offline.BoolderOfflineRepository
 import com.boolder.boolder.offline.OfflineAreaDownloader
+import com.boolder.boolder.view.map.filter.FiltersEventHandler
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
 import com.boolder.boolder.view.ticklist.TickedProblemSaver
@@ -38,7 +39,10 @@ class MapViewModel(
     private val topoDataAggregator: TopoDataAggregator,
     private val resources: Resources,
     private val boolderOfflineRepository: BoolderOfflineRepository
-) : ViewModel(), OfflineAreaDownloader, TickedProblemSaver {
+) : ViewModel(),
+    OfflineAreaDownloader,
+    TickedProblemSaver,
+    FiltersEventHandler {
 
     private val _screenStateFlow = MutableStateFlow(
         ScreenState(
@@ -49,6 +53,8 @@ class MapViewModel(
                 grades = ALL_GRADES
             ),
             popularFilterState = PopularFilterState(isEnabled = false),
+            projectsFilterState = ProjectsFilterState(projectIds = emptyList()),
+            tickedFilterState = TickedFilterState(tickedProblemIds = emptyList()),
             shouldShowFiltersBar = false
         )
     )
@@ -250,7 +256,9 @@ class MapViewModel(
         _screenStateFlow.update { it.copy(shouldShowFiltersBar = shouldShowFiltersBar) }
     }
 
-    fun onResetFiltersButtonClicked() {
+    // region FiltersEventHandler
+
+    override fun onResetFiltersButtonClicked() {
         _screenStateFlow.update {
             it.copy(
                 circuitState = null,
@@ -263,7 +271,7 @@ class MapViewModel(
         }
     }
 
-    fun onCircuitFilterChipClicked() {
+    override fun onCircuitFilterChipClicked() {
         viewModelScope.launch {
             val areaState = _screenStateFlow.value.areaState ?: return@launch
 
@@ -278,13 +286,13 @@ class MapViewModel(
         }
     }
 
-    fun onGradeFilterChipClicked() {
+    override fun onGradeFilterChipClicked() {
         viewModelScope.launch {
             _eventFlow.emit(Event.ShowGradeRanges(currentGradeRange = currentGradeRange))
         }
     }
 
-    fun onPopularFilterChipClicked() {
+    override fun onPopularFilterChipClicked() {
         val popularFilterValue = _screenStateFlow.value.popularFilterState.isEnabled
 
         _screenStateFlow.update {
@@ -293,6 +301,54 @@ class MapViewModel(
             )
         }
     }
+
+    override fun onProjectsFilterChipClicked() {
+        viewModelScope.launch {
+            val projectIds = _screenStateFlow.value.projectsFilterState.projectIds
+            val newProjectIds = if (projectIds.isNotEmpty()) {
+                emptyList()
+            } else {
+                tickedProblemRepository.getAllProjectIds()
+                    .also { if (it.isEmpty()) _eventFlow.emit(Event.WarnNoSavedProjects) }
+            }
+
+            _screenStateFlow.update {
+                it.copy(
+                    projectsFilterState = ProjectsFilterState(projectIds = newProjectIds),
+                    tickedFilterState = if (newProjectIds.isNotEmpty()) {
+                        TickedFilterState(tickedProblemIds = emptyList())
+                    } else {
+                        it.tickedFilterState
+                    }
+                )
+            }
+        }
+    }
+
+    override fun onTickedFilterChipClicked() {
+        viewModelScope.launch {
+            val tickedProblemIds = _screenStateFlow.value.tickedFilterState.tickedProblemIds
+            val newTickedProblemIds = if (tickedProblemIds.isNotEmpty()) {
+                emptyList()
+            } else {
+                tickedProblemRepository.getAllTickedProblemIds()
+                    .also { if (it.isEmpty()) _eventFlow.emit(Event.WarnNoTickedProblems) }
+            }
+
+            _screenStateFlow.update {
+                it.copy(
+                    tickedFilterState = TickedFilterState(tickedProblemIds = newTickedProblemIds),
+                    projectsFilterState = if (newTickedProblemIds.isNotEmpty()) {
+                        ProjectsFilterState(projectIds = emptyList())
+                    } else {
+                        it.projectsFilterState
+                    }
+                )
+            }
+        }
+    }
+
+    // endregion FiltersEventHandler
 
     fun onCircuitDepartureButtonClicked() {
         viewModelScope.launch {
@@ -414,6 +470,8 @@ class MapViewModel(
         val circuitState: CircuitState?,
         val gradeState: GradeState,
         val popularFilterState: PopularFilterState,
+        val projectsFilterState: ProjectsFilterState,
+        val tickedFilterState: TickedFilterState,
         val shouldShowFiltersBar: Boolean
     )
 
@@ -430,6 +488,10 @@ class MapViewModel(
 
     data class PopularFilterState(val isEnabled: Boolean)
 
+    data class ProjectsFilterState(val projectIds: List<Int>)
+
+    data class TickedFilterState(val tickedProblemIds: List<Int>)
+
     sealed interface Event {
         data class ShowAvailableCircuits(
             val selectedCircuit: Circuit?,
@@ -442,5 +504,8 @@ class MapViewModel(
 
         data class ZoomOnCircuitStartProblem(val problemId: Int) : Event
         data class ZoomOnArea(val area: Area) : Event
+
+        data object WarnNoSavedProjects : Event
+        data object WarnNoTickedProblems : Event
     }
 }

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/MapControlsOverlay.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/MapControlsOverlay.kt
@@ -22,6 +22,8 @@ import com.boolder.boolder.utils.extension.composeColor
 import com.boolder.boolder.utils.previewgenerator.dummyArea
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.map.MapViewModel
+import com.boolder.boolder.view.map.filter.DummyFiltersEventHandler
+import com.boolder.boolder.view.map.filter.FiltersEventHandler
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
 
@@ -31,14 +33,13 @@ fun MapControlsOverlay(
     circuitState: MapViewModel.CircuitState?,
     gradeState: MapViewModel.GradeState,
     popularState: MapViewModel.PopularFilterState,
+    projectsState: MapViewModel.ProjectsFilterState,
+    tickedState: MapViewModel.TickedFilterState,
     shouldShowFiltersBar: Boolean,
+    filtersEventHandler: FiltersEventHandler,
     onHideAreaName: () -> Unit,
     onAreaInfoClicked: () -> Unit,
     onSearchBarClicked: () -> Unit,
-    onCircuitFilterChipClicked: () -> Unit,
-    onGradeFilterChipClicked: () -> Unit,
-    onPopularFilterChipClicked: () -> Unit,
-    onResetFiltersClicked: () -> Unit,
     onCircuitStartClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -50,14 +51,13 @@ fun MapControlsOverlay(
             circuitState = circuitState,
             gradeState = gradeState,
             popularState = popularState,
+            projectsState = projectsState,
+            tickedState = tickedState,
             shouldShowFiltersBar = shouldShowFiltersBar,
+            filtersEventHandler = filtersEventHandler,
             onHideAreaName = onHideAreaName,
             onAreaInfoClicked = onAreaInfoClicked,
-            onSearchBarClicked = onSearchBarClicked,
-            onCircuitFilterChipClicked = onCircuitFilterChipClicked,
-            onGradeFilterChipClicked = onGradeFilterChipClicked,
-            onPopularFilterChipClicked = onPopularFilterChipClicked,
-            onResetFiltersClicked = onResetFiltersClicked,
+            onSearchBarClicked = onSearchBarClicked
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -102,14 +102,13 @@ private fun MapControlsOverlayPreview() {
                 grades = ALL_GRADES
             ),
             popularState = MapViewModel.PopularFilterState(isEnabled = false),
+            projectsState = MapViewModel.ProjectsFilterState(projectIds = emptyList()),
+            tickedState = MapViewModel.TickedFilterState(tickedProblemIds = emptyList()),
             shouldShowFiltersBar = true,
+            filtersEventHandler = DummyFiltersEventHandler,
             onHideAreaName = {},
             onAreaInfoClicked = {},
             onSearchBarClicked = {},
-            onCircuitFilterChipClicked = {},
-            onGradeFilterChipClicked = {},
-            onPopularFilterChipClicked = {},
-            onResetFiltersClicked = {},
             onCircuitStartClicked = {}
         )
     }

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/MapHeaderLayout.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/MapHeaderLayout.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -27,6 +28,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.boolder.boolder.R
 import com.boolder.boolder.domain.model.ALL_GRADES
@@ -104,80 +107,89 @@ private fun FiltersRow(
     val isProjectsFilterActive = projectsState.projectIds.isNotEmpty()
     val isTickedFilterActive = tickedState.tickedProblemIds.isNotEmpty()
 
-    val showResetButton = isCircuitFilterActive || isGradeFilterActive || isPopularFilterActive
+    val showResetButton = isCircuitFilterActive
+        || isGradeFilterActive
+        || isPopularFilterActive
+        || isProjectsFilterActive
+        || isTickedFilterActive
 
-    LazyRow(
-        modifier = Modifier.fillMaxWidth(),
-        state = lazyRowState,
-        horizontalArrangement = spacedBy(8.dp),
-        contentPadding = PaddingValues(horizontal = 16.dp)
+    Row(
+        horizontalArrangement = spacedBy(8.dp)
     ) {
-        if (showResetButton) {
-            item(key = "reset_button") {
-                MapFilterResetChip(
-                    modifier = Modifier.animateItemPlacement(),
-                    onClick = filtersEventHandler::onResetFiltersButtonClicked
-                )
-            }
+        AnimatedVisibility(visible = showResetButton) {
+            MapFilterResetChip(
+                modifier = Modifier.padding(start = 16.dp),
+                onClick = filtersEventHandler::onResetFiltersButtonClicked
+            )
         }
 
-        if (showCircuitFilterChip) {
-            item(key = circuitState?.circuitId) {
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            state = lazyRowState,
+            horizontalArrangement = spacedBy(8.dp),
+            contentPadding = PaddingValues(
+                start = if (showResetButton) 0.dp else 16.dp,
+                end = 16.dp
+            )
+        ) {
+            if (showCircuitFilterChip) {
+                item(key = circuitState?.circuitId) {
+                    MapFilterChip(
+                        modifier = Modifier.animateItemPlacement(),
+                        selected = isCircuitFilterActive,
+                        label = circuitState?.color?.localizedName()
+                            ?: stringResource(id = R.string.circuits),
+                        iconRes = R.drawable.ic_route,
+                        onClick = filtersEventHandler::onCircuitFilterChipClicked
+                    )
+
+                    LaunchedEffect(key1 = circuitState) { lazyRowState.animateScrollToItem(index = 0) }
+                }
+            }
+
+            item(key = gradeState.gradeRangeButtonTitle) {
                 MapFilterChip(
                     modifier = Modifier.animateItemPlacement(),
-                    selected = isCircuitFilterActive,
-                    label = circuitState?.color?.localizedName()
-                        ?: stringResource(id = R.string.circuits),
-                    iconRes = R.drawable.ic_route,
-                    onClick = filtersEventHandler::onCircuitFilterChipClicked
+                    selected = isGradeFilterActive,
+                    label = gradeState.gradeRangeButtonTitle,
+                    iconRes = R.drawable.ic_signal_cellular_alt,
+                    onClick = filtersEventHandler::onGradeFilterChipClicked
                 )
+            }
 
-                LaunchedEffect(key1 = circuitState) { lazyRowState.animateScrollToItem(index = 0) }
+            item(key = "popular-filter") {
+                MapFilterChip(
+                    modifier = Modifier.animateItemPlacement(),
+                    selected = isPopularFilterActive,
+                    label = stringResource(id = R.string.filter_popular),
+                    iconRes = R.drawable.ic_favorite_border,
+                    onClick = filtersEventHandler::onPopularFilterChipClicked
+                )
+            }
+
+            item(key = "projects-filter") {
+                MapFilterChip(
+                    modifier = Modifier.animateItemPlacement(),
+                    selected = isProjectsFilterActive,
+                    label = stringResource(id = R.string.filter_projects),
+                    iconRes = R.drawable.ic_star_outline,
+                    onClick = filtersEventHandler::onProjectsFilterChipClicked
+                )
+            }
+
+            item(key = "ticked-filter") {
+                MapFilterChip(
+                    modifier = Modifier.animateItemPlacement(),
+                    selected = isTickedFilterActive,
+                    label = stringResource(id = R.string.filter_ticked),
+                    iconRes = R.drawable.ic_check_circle,
+                    onClick = filtersEventHandler::onTickedFilterChipClicked
+                )
             }
         }
 
-        item(key = gradeState.gradeRangeButtonTitle) {
-            MapFilterChip(
-                modifier = Modifier.animateItemPlacement(),
-                selected = isGradeFilterActive,
-                label = gradeState.gradeRangeButtonTitle,
-                iconRes = R.drawable.ic_signal_cellular_alt,
-                onClick = filtersEventHandler::onGradeFilterChipClicked
-            )
-        }
-
-        item(key = "popular-filter") {
-            MapFilterChip(
-                modifier = Modifier.animateItemPlacement(),
-                selected = isPopularFilterActive,
-                label = stringResource(id = R.string.filter_popular),
-                iconRes = R.drawable.ic_favorite_border,
-                onClick = filtersEventHandler::onPopularFilterChipClicked
-            )
-        }
-
-        item(key = "projects-filter") {
-            MapFilterChip(
-                modifier = Modifier.animateItemPlacement(),
-                selected = isProjectsFilterActive,
-                label = stringResource(id = R.string.filter_projects),
-                iconRes = R.drawable.ic_star_outline,
-                onClick = filtersEventHandler::onProjectsFilterChipClicked
-            )
-        }
-
-        item(key = "ticked-filter") {
-            MapFilterChip(
-                modifier = Modifier.animateItemPlacement(),
-                selected = isTickedFilterActive,
-                label = stringResource(id = R.string.filter_ticked),
-                iconRes = R.drawable.ic_check_circle,
-                onClick = filtersEventHandler::onTickedFilterChipClicked
-            )
-        }
+        LaunchedEffect(key1 = Unit) { lazyRowState.scrollToItem(index = 0) }
     }
-
-    LaunchedEffect(key1 = Unit) { lazyRowState.scrollToItem(index = 0) }
 }
 
 @Composable
@@ -233,15 +245,14 @@ private fun MapFilterChip(
 
 @PreviewLightDark
 @Composable
-private fun MapHeaderLayoutPreview() {
+private fun MapHeaderLayoutPreview(
+    @PreviewParameter(MapHeaderLayoutPreviewParameterProvider::class)
+    circuitState: MapViewModel.CircuitState?
+) {
     BoolderTheme {
         MapHeaderLayout(
             offlineAreaItem = dummyOfflineAreaItem(),
-            circuitState = MapViewModel.CircuitState(
-                circuitId = 42,
-                color = CircuitColor.BLUE,
-                showCircuitStartButton = true
-            ),
+            circuitState = circuitState,
             gradeState = MapViewModel.GradeState(
                 gradeRangeButtonTitle = stringResource(id = R.string.grade),
                 grades = ALL_GRADES
@@ -256,4 +267,15 @@ private fun MapHeaderLayoutPreview() {
             onSearchBarClicked = {}
         )
     }
+}
+
+private class MapHeaderLayoutPreviewParameterProvider : PreviewParameterProvider<MapViewModel.CircuitState?> {
+    override val values = sequenceOf(
+        null,
+        MapViewModel.CircuitState(
+            circuitId = 42,
+            color = CircuitColor.BLUE,
+            showCircuitStartButton = true
+        )
+    )
 }

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/MapHeaderLayout.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/MapHeaderLayout.kt
@@ -5,13 +5,17 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -24,7 +28,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -113,14 +123,37 @@ private fun FiltersRow(
         || isProjectsFilterActive
         || isTickedFilterActive
 
-    Row(
-        horizontalArrangement = spacedBy(8.dp)
-    ) {
+    val separatorVisibilityThreshold = 15f
+    val listOffset by remember {
+        derivedStateOf {
+            (lazyRowState.firstVisibleItemIndex * 100f + lazyRowState.firstVisibleItemScrollOffset)
+                .coerceAtMost(separatorVisibilityThreshold)
+        }
+    }
+
+    Row {
         AnimatedVisibility(visible = showResetButton) {
-            MapFilterResetChip(
+            Row(
                 modifier = Modifier.padding(start = 16.dp),
-                onClick = filtersEventHandler::onResetFiltersButtonClicked
-            )
+                horizontalArrangement = spacedBy(8.dp)
+            ) {
+                MapFilterResetChip(onClick = filtersEventHandler::onResetFiltersButtonClicked)
+
+                Box(
+                    modifier = Modifier
+                        .width(1.dp)
+                        .height(48.dp)
+                        .graphicsLayer { alpha = listOffset / separatorVisibilityThreshold }
+                        .background(
+                            brush = Brush.verticalGradient(
+                                0f to Color.Transparent,
+                                .33f to MaterialTheme.colorScheme.surface,
+                                .66f to MaterialTheme.colorScheme.surface,
+                                1f to Color.Transparent
+                            )
+                        )
+                )
+            }
         }
 
         LazyRow(

--- a/app/src/main/java/com/boolder/boolder/view/map/filter/FiltersEventHandler.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/filter/FiltersEventHandler.kt
@@ -1,0 +1,19 @@
+package com.boolder.boolder.view.map.filter
+
+interface FiltersEventHandler {
+    fun onCircuitFilterChipClicked()
+    fun onGradeFilterChipClicked()
+    fun onPopularFilterChipClicked()
+    fun onProjectsFilterChipClicked()
+    fun onTickedFilterChipClicked()
+    fun onResetFiltersButtonClicked()
+}
+
+object DummyFiltersEventHandler : FiltersEventHandler {
+    override fun onCircuitFilterChipClicked() {}
+    override fun onGradeFilterChipClicked() {}
+    override fun onPopularFilterChipClicked() {}
+    override fun onProjectsFilterChipClicked() {}
+    override fun onTickedFilterChipClicked() {}
+    override fun onResetFiltersButtonClicked() {}
+}

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -81,7 +81,13 @@
     <string name="apply">Appliquer</string>
     <string name="custom">Personnalisé</string>
 
-    <string name="popular">Populaires</string>
+    <string name="filter_popular">Populaires</string>
+    <string name="filter_projects">Projets</string>
+    <string name="filter_ticked">Réussies</string>
+    <string name="filter_warning_no_projects_message">Enregistrez votre premier projet pour utiliser ce filtre.</string>
+    <string name="filter_warning_no_projects_title">Vous n\'avez pas encore de projet</string>
+    <string name="filter_warning_no_ticks_message">Enregistrez votre première voie réussie pour utiliser ce filtre.</string>
+    <string name="filter_warning_no_ticks_title">Vous n\'avez pas encore de voie réussie</string>
 
     <string name="area_overview_area_info">Infos secteur</string>
     <string name="area_overview_problems">Voies</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,7 +84,13 @@
     <string name="apply">Apply</string>
     <string name="custom">Custom</string>
 
-    <string name="popular">Popular</string>
+    <string name="filter_popular">Popular</string>
+    <string name="filter_projects">Projects</string>
+    <string name="filter_ticked">Ticked</string>
+    <string name="filter_warning_no_projects_message">Add your first project to use this filter.</string>
+    <string name="filter_warning_no_projects_title">You don\'t have any projects yet</string>
+    <string name="filter_warning_no_ticks_message">Tick your first problem to use this filter.</string>
+    <string name="filter_warning_no_ticks_title">You don\'t have any ticks yet</string>
 
     <string name="area_overview_area_info">Area info</string>
     <string name="area_overview_problems">Problems</string>


### PR DESCRIPTION
Problems could be saved as projects or ticked, but the associated filters were missing.
This commit implements them.

The "Projects" and "Ticked" filters are mutually exclusive, but can be used in combination with all the other previously implemented filters, as shown in this screen recording:

https://github.com/boolder-org/boolder-android/assets/8343416/b544e882-b860-4e32-a069-1f90c79e06a9

|No projects saved|No ticked problems|
|-|-|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/1d22f20c-2b21-408b-870f-8e08d6884fe3" width=400 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/c81bca1d-524a-43f5-b477-c4a2b673f017" width=400 />|
