### PR TITLE
Fix back navigation issue from a secondary fragment to the map fragment

### DIFF
--- a/app/src/main/java/com/boolder/boolder/utils/LocationProvider.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/LocationProvider.kt
@@ -16,7 +16,11 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.boolder.boolder.R.string
 import com.google.android.gms.common.api.ResolvableApiException
-import com.google.android.gms.location.*
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.LocationSettingsRequest
+import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationToken
 import com.google.android.gms.tasks.CancellationTokenSource
 import com.google.android.gms.tasks.OnTokenCanceledListener
@@ -25,6 +29,10 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
 class LocationProvider(private val activity: FragmentActivity) {
+    /** An activity owning the [LocationProvider] instance. */
+    interface Owner {
+        val locationProvider: LocationProvider
+    }
 
     private var isWaitingPosition = false
     private var locationPermissionRequest: ActivityResultLauncher<Array<String>> = activity.registerForActivityResult(

--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areacircuit/AreaCircuitFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areacircuit/AreaCircuitFragment.kt
@@ -52,7 +52,7 @@ class AreaCircuitFragment : Fragment() {
             bundleOf(KEY_PROBLEM to problem)
         )
 
-        findNavController().popBackStack(R.id.map_fragment, inclusive = false)
+        findNavController().navigate(resId = R.id.map_fragment)
     }
 
     private fun onSeeOnMapClicked() {
@@ -61,6 +61,6 @@ class AreaCircuitFragment : Fragment() {
             bundleOf(KEY_CIRCUIT_ID to args.circuitId)
         )
 
-        findNavController().popBackStack(R.id.map_fragment, inclusive = false)
+        findNavController().navigate(resId = R.id.map_fragment)
     }
 }

--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewFragment.kt
@@ -56,7 +56,7 @@ class AreaOverviewFragment : Fragment() {
             bundleOf(KEY_AREA_ID to args.areaId)
         )
 
-        findNavController().popBackStack(R.id.map_fragment, inclusive = false)
+        findNavController().navigate(resId = R.id.map_fragment)
     }
 
     private fun onAreaProblemsCountClicked() {

--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areaproblems/AreaProblemsFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areaproblems/AreaProblemsFragment.kt
@@ -49,6 +49,6 @@ class AreaProblemsFragment : Fragment() {
             result = bundleOf(KEY_PROBLEM to problem)
         )
 
-        findNavController().popBackStack(destinationId = R.id.map_fragment, inclusive = false)
+        findNavController().navigate(resId = R.id.map_fragment)
     }
 }

--- a/app/src/main/java/com/boolder/boolder/view/main/MainActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/main/MainActivity.kt
@@ -8,14 +8,20 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.boolder.boolder.R
 import com.boolder.boolder.databinding.ActivityMainBinding
+import com.boolder.boolder.utils.LocationProvider
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), LocationProvider.Owner {
 
     private lateinit var binding: ActivityMainBinding
+    private lateinit var _locationProvider: LocationProvider
+
+    override val locationProvider: LocationProvider
+        get() = _locationProvider
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        _locationProvider = LocationProvider(this)
 
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
@@ -203,8 +203,7 @@ class BoolderMap @JvmOverloads constructor(
             if (features.isValue) {
                 val feature = features.value?.firstOrNull()?.feature
                     ?: run {
-                        unselectProblem()
-                        listener?.onTopoUnselected()
+                        unselectProblem(notifyListener = true)
                         return@queryRenderedFeatures
                     }
 
@@ -274,15 +273,15 @@ class BoolderMap @JvmOverloads constructor(
         previousSelectedFeatureId = featureId
     }
 
-    private fun unselectProblem() {
-        previousSelectedFeatureId?.let {
-            getMapboxMap().setFeatureState(
-                "problems",
-                BoolderMapConfig.problemsSourceLayerId,
-                it,
-                Value.fromJson("""{"selected": false}""").value!!
-            )
-        }
+    fun unselectProblem(notifyListener: Boolean = false) {
+        val previousSelectedFeatureId = previousSelectedFeatureId ?: return
+        getMapboxMap().setFeatureState(
+            "problems",
+            BoolderMapConfig.problemsSourceLayerId,
+            previousSelectedFeatureId,
+            Value.fromJson("""{"selected": false}""").value!!
+        )
+        if (notifyListener) listener?.onTopoUnselected()
     }
 
     fun updateCircuit(circuitId: Long?) {

--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -72,14 +72,9 @@ class MapFragment : Fragment(), BoolderMapListener {
     private val mapViewModel by viewModel<MapViewModel>()
     private val layerFactory by inject<MapboxStyleFactory>()
 
-    private lateinit var locationProvider: LocationProvider
-
     private lateinit var bottomSheetBehavior: BottomSheetBehavior<FrameLayout>
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        locationProvider = LocationProvider(requireActivity())
-    }
+    private val locationProvider: LocationProvider
+        get() = (requireActivity() as LocationProvider.Owner).locationProvider
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/boolder/boolder/view/ticklist/TickListFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/ticklist/TickListFragment.kt
@@ -83,7 +83,7 @@ class TickListFragment : Fragment() {
             bundleOf(KEY_PROBLEM to problem)
         )
 
-        findNavController().popBackStack(R.id.map_fragment, inclusive = false)
+        findNavController().navigate(resId = R.id.map_fragment)
     }
 
     private fun onTickListFileReadyToExport(exportFile: File) {


### PR DESCRIPTION
Reproduction steps:

1. Open the app.
2. Open some secondary screen, for example, Area/Problems.
3. Click on a problem.
4. Press back.

Expected: Area/Problems screen is displayed
Actual: the app is closed