### PR TITLE
Show full-screen mode topo photo with pinch-to-zoom

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,4 +118,7 @@ dependencies {
 
     // Work manager
     implementation("androidx.work:work-runtime-ktx:2.9.0")
+    
+    // Zoomy
+    implementation("io.github.imablanco:zoomy:1.0.0")
 }

--- a/app/src/main/java/com/boolder/boolder/view/detail/TopoFullScreenFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/TopoFullScreenFragment.kt
@@ -1,0 +1,50 @@
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import coil.load
+import com.ablanco.zoomy.Zoomy
+import com.boolder.boolder.databinding.FragmentTopoFullScreenBinding
+
+class TopoFullScreenFragment : Fragment() {
+
+    companion object {
+        private const val IMAGE_URL = "image_url"
+
+        fun newInstance(imageUrl: String): TopoFullScreenFragment {
+            val args = Bundle().apply {
+                putString(IMAGE_URL, imageUrl)
+            }
+            return TopoFullScreenFragment().apply {
+                arguments = args
+            }
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val binding = FragmentTopoFullScreenBinding.inflate(inflater, container, false)
+        val imageUrl = arguments?.getString(IMAGE_URL)
+
+        imageUrl?.let {
+            binding.imageView.load(it) {
+                allowHardware(false)
+            }
+        }
+
+        binding.imageView.setOnClickListener {
+            activity?.supportFragmentManager?.popBackStack()
+        }
+
+        Zoomy.Builder(activity).target(binding.imageView).tapListener { activity?.supportFragmentManager?.popBackStack() }
+            .register()
+
+
+        return binding.root
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/view/detail/TopoView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/TopoView.kt
@@ -20,6 +20,7 @@ import androidx.core.graphics.Insets
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
 import androidx.core.view.updateLayoutParams
+import androidx.fragment.app.FragmentActivity
 import coil.load
 import com.boolder.boolder.R
 import com.boolder.boolder.databinding.ViewTopoBinding
@@ -139,6 +140,16 @@ class TopoView(
         }
     }
 
+    private fun showFullScreenImage(imageUrl: String) {
+        val fragmentManager = (context as FragmentActivity).supportFragmentManager
+        val fragmentTransaction = fragmentManager.beginTransaction()
+
+        val fullScreenFragment = TopoFullScreenFragment.newInstance(imageUrl)
+        fragmentTransaction.add(android.R.id.content, fullScreenFragment)
+            .addToBackStack(null)
+            .commit()
+    }
+
     private fun updateCircuitControls(circuitInfo: CircuitInfo?) {
         binding.circuitControlsComposeView.setContent {
             circuitInfo ?: return@setContent
@@ -188,6 +199,9 @@ class TopoView(
                     binding.picture.setPadding(0)
                     binding.progressCircular.isVisible = false
                     onProblemPictureLoaded(topo)
+                    binding.picture.setOnClickListener {
+                        showFullScreenImage(topo.pictureUrl ?: "")
+                    }
                 },
                 onError = { _, _ -> loadErrorPicture() }
             )

--- a/app/src/main/res/layout/fragment_topo_full_screen.xml
+++ b/app/src/main/res/layout/fragment_topo_full_screen.xml
@@ -1,0 +1,11 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="fitCenter"/>
+</FrameLayout>


### PR DESCRIPTION
This is a preview version for resolving #21 

I split #21  into three small tasks. I have implemented the two first. The core challenge I'm facing is similar to the method used for displaying the topo photo in Topoview.kt, but I'm unsure how to adapt this approach for composing the problem's elements(circle and line) on the topo photo in full-screen mode. I would greatly appreciate it if you could review my code and provide insights or suggestions on how to proceed with this task.

- [x]   click the topo photo to show full-screen mode topo photo
- [x]   pinch-to-zoom the topo photo
- [ ]    compose problem's starting circle and problem line to topo photo in full-screen mode  
