### PR TITLE
Fix circuit start button text color

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/compose/degreecounts/DegreeCountsChart.kt
+++ b/app/src/main/java/com/boolder/boolder/view/compose/degreecounts/DegreeCountsChart.kt
@@ -174,7 +174,7 @@ private fun DegreesLabels(degrees: Set<String>) {
                     .padding(4.dp),
                 text = it,
                 style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.outline,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
             )
         }

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/MapControlsOverlay.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/MapControlsOverlay.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -74,7 +73,8 @@ fun MapControlsOverlay(
                     text = stringResource(id = R.string.circuit_start),
                     style = MaterialTheme.typography.labelLarge,
                     color = when (val circuitColor = circuitState.color) {
-                        CircuitColor.WHITE -> Color.Black
+                        CircuitColor.WHITE,
+                        CircuitColor.BLACK -> MaterialTheme.colorScheme.onSurface
                         else -> circuitColor.composeColor()
                     }
                 )


### PR DESCRIPTION
The circuit start button text color was not properly adapted in dark mode for a black circuit:

<img src="https://github.com/boolder-org/boolder-android/assets/8343416/9ea757f7-4331-4f0f-91c0-af879582d45a" width=300 />

### Screenshots after fix:

|Light|Dark|
|-|-|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/7a9a7292-66ea-41e4-ab65-f3efff9294e6" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/85510485-1888-4837-8602-d5515c19f550" width=300 />|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/6596ac8d-6453-4c60-9b8a-43396a59f0b6" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/ff707fd6-35a9-4bfe-b94b-2ac9618559cf" width=300 />|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/24391dca-0ec1-49d9-8b99-839c311a8f2b" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/c3435288-d837-4616-92e2-a996d8c7dc79" width=300 />|
