### PR TITLE
Avoid crashing on unknown area

### DIFF
--- a/app/src/main/java/com/boolder/boolder/data/database/dao/AreaDao.kt
+++ b/app/src/main/java/com/boolder/boolder/data/database/dao/AreaDao.kt
@@ -14,7 +14,7 @@ interface AreaDao {
     suspend fun areasByName(name: String): List<AreasEntity>
 
     @Query("SELECT * FROM areas WHERE id = :id")
-    suspend fun getAreaById(id: Int): AreasEntity
+    suspend fun getAreaById(id: Int): AreasEntity?
 
     @Query("SELECT * FROM areas ORDER BY name COLLATE UNICODE")
     suspend fun getAllAreas(): List<AreasEntity>

--- a/app/src/main/java/com/boolder/boolder/data/database/repository/AreaRepository.kt
+++ b/app/src/main/java/com/boolder/boolder/data/database/repository/AreaRepository.kt
@@ -17,8 +17,8 @@ class AreaRepository(
     suspend fun areasByName(name: String): List<AreasEntity> =
         areaDao.areasByName(name)
 
-    suspend fun getAreaById(id: Int): Area =
-        areaDao.getAreaById(id).convert()
+    suspend fun getAreaById(id: Int): Area? =
+        areaDao.getAreaById(id)?.convert()
 
     suspend fun getAllAreas(): List<Area> =
         areaDao.getAllAreas().map { it.convert() }

--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewScreen.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewScreen.kt
@@ -100,7 +100,11 @@ internal fun AreaOverviewScreen(
             )
         },
         floatingActionButton = {
-            if (displayShowOnMapButton) SeeOnMapButton(onClick = onSeeOnMapClicked)
+            if (screenState is AreaOverviewViewModel.ScreenState.UnknownArea || !displayShowOnMapButton) {
+                return@Scaffold
+            }
+
+            SeeOnMapButton(onClick = onSeeOnMapClicked)
         },
         floatingActionButtonPosition = FabPosition.Center,
         content = {
@@ -115,6 +119,7 @@ internal fun AreaOverviewScreen(
                     onCircuitClicked = onCircuitClicked,
                     onPoiClicked = onPoiClicked
                 )
+                is AreaOverviewViewModel.ScreenState.UnknownArea -> AreaOverviewScreenUnknownArea()
             }
         }
     )
@@ -338,6 +343,22 @@ private fun GradeCountsItem(
     }
 }
 
+@Composable
+private fun AreaOverviewScreenUnknownArea() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = stringResource(id = R.string.area_overview_error_cannot_display_area),
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
 @PreviewLightDark
 @Composable
 private fun AreaOverviewScreenPreview(
@@ -395,6 +416,7 @@ private class AreaOverviewScreenPreviewParameterProvider : PreviewParameterProvi
                 )
             ),
             offlineAreaItemStatus = OfflineAreaItemStatus.NotDownloaded
-        )
+        ),
+        AreaOverviewViewModel.ScreenState.UnknownArea
     )
 }

--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewViewModel.kt
@@ -29,8 +29,11 @@ class AreaOverviewViewModel(
     init {
         viewModelScope.launch {
             val areaId = savedStateHandle.get<Int>("area_id") ?: return@launch
+            val area = areaRepository.getAreaById(areaId) ?: run {
+                _screenState.value = ScreenState.UnknownArea
+                return@launch
+            }
 
-            val area = areaRepository.getAreaById(areaId)
             val circuits = circuitRepository.getAvailableCircuits(areaId)
             val accessesFromPoi = areaRepository.getAccessesFromPoiByAreaId(areaId)
 
@@ -91,5 +94,7 @@ class AreaOverviewViewModel(
             val accessesFromPoi: List<AccessFromPoi>,
             val offlineAreaItemStatus: OfflineAreaItemStatus
         ) : ScreenState
+
+        data object UnknownArea : ScreenState
     }
 }

--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areaproblems/AreaProblemsScreen.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areaproblems/AreaProblemsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -120,6 +121,8 @@ internal fun AreaProblemsScreen(
                     )
                 },
                 actions = {
+                    if (screenState is AreaProblemsViewModel.ScreenState.UnknownArea) return@TopAppBar
+
                     IconButton(
                         modifier = Modifier
                             .padding(8.dp)
@@ -155,6 +158,7 @@ internal fun AreaProblemsScreen(
                     contentPadding = it,
                     onProblemClicked = onProblemClicked
                 )
+                is AreaProblemsViewModel.ScreenState.UnknownArea -> AreaProblemsScreenUnknownArea()
             }
         }
     )
@@ -238,6 +242,22 @@ private fun AreaProblemsScreenContent(
     }
 }
 
+@Composable
+private fun AreaProblemsScreenUnknownArea() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = stringResource(id = R.string.area_problems_error_cannot_display_area),
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
 @PreviewLightDark
 @Composable
 private fun AreaProblemsScreenPreview(
@@ -271,7 +291,8 @@ private class AreaProblemsScreenPreviewParameterProvider : PreviewParameterProvi
                     featured = true
                 )
             }
-        )
+        ),
+        AreaProblemsViewModel.ScreenState.UnknownArea
     )
 
 }

--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areaproblems/AreaProblemsViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areaproblems/AreaProblemsViewModel.kt
@@ -26,8 +26,8 @@ internal class AreaProblemsViewModel(
         .debounce(500L)
         .map { query ->
             val areaId = savedStateHandle.get<Int>("area_id") ?: -1
+            val area = areaRepository.getAreaById(areaId) ?: return@map ScreenState.UnknownArea
 
-            val area = areaRepository.getAreaById(areaId)
             val allProblems = problemRepository.problemsForArea(areaId, query)
             val allPopularProblems = allProblems.filter { it.featured }
 
@@ -50,5 +50,7 @@ internal class AreaProblemsViewModel(
             val problems: List<Problem>,
             val popularProblems: List<Problem>
         ) : ScreenState
+
+        data object UnknownArea : ScreenState
     }
 }

--- a/app/src/main/java/com/boolder/boolder/view/map/MapViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapViewModel.kt
@@ -144,7 +144,7 @@ class MapViewModel(
 
     fun onAreaSelected(areaId: Int) {
         viewModelScope.launch {
-            val area = areaRepository.getAreaById(areaId)
+            val area = areaRepository.getAreaById(areaId) ?: return@launch
 
             _eventFlow.emit(Event.ZoomOnArea(area))
         }
@@ -205,7 +205,8 @@ class MapViewModel(
 
             if (currentAreaState?.area?.id == areaId) return@launch
 
-            val area = areaRepository.getAreaById(areaId)
+            val area = areaRepository.getAreaById(areaId) ?: return@launch
+
             val offlineStatus = boolderOfflineRepository.getStatusForAreaId(areaId)
 
             val newAreaState = OfflineAreaItem(

--- a/app/src/main/java/com/boolder/boolder/view/ticklist/TickListViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/ticklist/TickListViewModel.kt
@@ -53,10 +53,11 @@ internal class TickListViewModel(
                 val problemEntity = problemRepository.problemById(it.problemId)
                     ?: return@mapNotNull null
 
-                val areaName = areaRepository.getAreaById(problemEntity.areaId).name
+                val area = areaRepository.getAreaById(problemEntity.areaId)
+                    ?: return@mapNotNull null
 
                 problemEntity.convert(
-                    areaName = areaName,
+                    areaName = area.name,
                     tickStatus = it.tickStatus
                 )
             }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -102,9 +102,11 @@
     <string name="area_overview_photos_deletion_dialog_text">Voulez-vous supprimer les photos téléchargées ?</string>
     <string name="area_overview_photos_deletion_dialog_confirm_button">Supprimer</string>
     <string name="area_overview_photos_deletion_dialog_cancel_button">Annuler</string>
+    <string name="area_overview_error_cannot_display_area">Impossible d\'afficher les informations de ce secteur</string>
     <string name="area_circuit_beginner_friendly">Ce circuit convient aux débutants</string>
     <string name="area_circuit_dangerous">Ce circuit est dangereux : certains blocs sont très hauts et/ou avec une réception difficile</string>
     <string name="area_circuit_see_on_map">Voir sur la carte</string>
+    <string name="area_problems_error_cannot_display_area">Impossible d\'afficher les blocs de ce secteur</string>
     <string name="area_problems_tab_all">Toutes</string>
     <string name="area_problems_tab_popular">Populaires</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,9 +105,11 @@
     <string name="area_overview_photos_deletion_dialog_text">Are you sure to delete the downloaded photos?</string>
     <string name="area_overview_photos_deletion_dialog_confirm_button">Delete</string>
     <string name="area_overview_photos_deletion_dialog_cancel_button">Cancel</string>
+    <string name="area_overview_error_cannot_display_area">Can\'t display information for this area</string>
     <string name="area_circuit_beginner_friendly">This circuit is beginner friendly</string>
     <string name="area_circuit_dangerous">This circuit is dangerous: some boulders are very high and/or with difficult landings</string>
     <string name="area_circuit_see_on_map">See on the map</string>
+    <string name="area_problems_error_cannot_display_area">Can\'t display the boulder problems for this area</string>
     <string name="area_problems_tab_all">All</string>
     <string name="area_problems_tab_popular">Popular</string>
 


### PR DESCRIPTION
The app was crashing when tapping on a new area displayed on the map without having the database updated yet.

### Before

https://github.com/boolder-org/boolder-android/assets/8343416/6305ddb8-c86d-4f5b-b73d-e0f043d48ff4

### After

https://github.com/boolder-org/boolder-android/assets/8343416/f6452ab2-c6ff-44f2-a26d-f4aa639c90e6

Also, the area overview and area problems screens will display an error message:

|Area overview|Area problems|
|-|-|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/9a2b2efc-631e-452d-8a16-9d9712f30967" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/622a18dc-8ab3-4216-a2a3-7cf643ad4a77" width=300 />|

Finally, the tick list screen has been adapted, so that it will not show any problems from the missing area.

Resolves #99 