### PR TITLE
Display warning icon in area bar

### DIFF
--- a/app/src/main/java/com/boolder/boolder/utils/previewgenerator/AreaGenerator.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/previewgenerator/AreaGenerator.kt
@@ -7,12 +7,13 @@ fun dummyArea(
     id: Int = 1,
     name: String = "Roche aux Oiseaux",
     description: String = "La Roche aux Oiseaux is a small and quite nice area.",
+    warning: String? = "February 2022: the orange circuit's paint is not visible anymore.",
     problemsCount: Int = 513
 ) = Area(
     id = id,
     name = name,
     description = description,
-    warning = "February 2022: the orange circuit's paint is not visible anymore.",
+    warning = warning,
     tags = listOf(
         R.string.tags_popular,
         R.string.tags_beginner_friendly,

--- a/app/src/main/java/com/boolder/boolder/utils/previewgenerator/OfflineAreaItemGenerator.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/previewgenerator/OfflineAreaItemGenerator.kt
@@ -1,11 +1,13 @@
 package com.boolder.boolder.utils.previewgenerator
 
+import com.boolder.boolder.domain.model.Area
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
 
 fun dummyOfflineAreaItem(
+    area: Area = dummyArea(),
     status: OfflineAreaItemStatus = OfflineAreaItemStatus.NotDownloaded
 ) = OfflineAreaItem(
-    area = dummyArea(),
+    area = area,
     status = status
 )

--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewScreen.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewScreen.kt
@@ -200,12 +200,23 @@ private fun AreaOverviewScreenContent(
                         }
 
                         screenState.area.warning?.let {
-                            Text(
-                                text = it,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = Color.BoolderOrange,
-                                textAlign = TextAlign.Justify
-                            )
+                            Row(
+                                horizontalArrangement = spacedBy(16.dp),
+                                verticalAlignment = Alignment.Top
+                            ) {
+                                Icon(
+                                    painterResource(id = R.drawable.ic_round_warning),
+                                    contentDescription = null,
+                                    tint = Color.BoolderOrange
+                                )
+
+                                Text(
+                                    text = it,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = Color.BoolderOrange,
+                                    textAlign = TextAlign.Justify
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/composable/download/AreaPhotosDownloadItem.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/composable/download/AreaPhotosDownloadItem.kt
@@ -8,18 +8,19 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -92,22 +93,20 @@ internal fun AreaPhotosDownloadItem(
             )
         }
 
-        Row(
+        OutlinedButton(
             modifier = Modifier
-                .clickable(onClick = param.onClick)
-                .padding(16.dp)
+                .fillMaxWidth()
+                .padding(16.dp),
+            onClick = param.onClick
         ) {
-            Text(
-                modifier = Modifier.weight(1f),
-                text = param.text,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-
             Icon(
                 painter = painterResource(id = param.iconRes),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurface
+                contentDescription = null
             )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Text(text = param.text)
         }
     }
 

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/AreaName.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/AreaName.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -40,7 +41,9 @@ import androidx.work.WorkManager
 import com.boolder.boolder.R
 import com.boolder.boolder.offline.WORK_DATA_PROGRESS
 import com.boolder.boolder.offline.getDownloadTopoImagesWorkName
+import com.boolder.boolder.utils.previewgenerator.dummyArea
 import com.boolder.boolder.utils.previewgenerator.dummyOfflineAreaItem
+import com.boolder.boolder.view.compose.BoolderOrange
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
@@ -95,12 +98,26 @@ internal fun AreaName(
             AreaOfflineStatusInfo(item = offlineAreaItem)
         }
 
-        Icon(
-            modifier = Modifier.iconActionModifier(onClick = onAreaInfoClicked),
-            painter = painterResource(id = R.drawable.ic_outline_info),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary
-        )
+        Box {
+            Icon(
+                modifier = Modifier.iconActionModifier(onClick = onAreaInfoClicked),
+                painter = painterResource(id = R.drawable.ic_outline_info),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary
+            )
+
+            if (offlineAreaItem?.area?.warning != null) {
+                Icon(
+                    modifier = Modifier
+                        .padding(6.dp)
+                        .size(16.dp)
+                        .align(Alignment.TopEnd),
+                    painter = painterResource(id = R.drawable.ic_round_warning),
+                    contentDescription = null,
+                    tint = Color.BoolderOrange
+                )
+            }
+        }
     }
 }
 
@@ -177,21 +194,32 @@ private fun IconDownloaded(
 @Composable
 private fun AreaNamePreview(
     @PreviewParameter(AreaNamePreviewParameterProvider::class)
-    offlineAreaItemStatus: OfflineAreaItemStatus
+    offlineAreaItem: OfflineAreaItem
 ) {
     BoolderTheme {
         AreaName(
-            offlineAreaItem = dummyOfflineAreaItem(status = offlineAreaItemStatus),
+            offlineAreaItem = offlineAreaItem,
             onHideAreaName = {},
             onAreaInfoClicked = {}
         )
     }
 }
 
-class AreaNamePreviewParameterProvider : PreviewParameterProvider<OfflineAreaItemStatus> {
-    override val values = sequenceOf(
+class AreaNamePreviewParameterProvider : PreviewParameterProvider<OfflineAreaItem> {
+
+    override val values = listOf(
         OfflineAreaItemStatus.NotDownloaded,
         OfflineAreaItemStatus.Downloading(areaId = 0),
         OfflineAreaItemStatus.Downloaded(folderSize = "50 MB")
     )
+        .flatMap {
+            listOf(
+                dummyOfflineAreaItem(
+                    area = dummyArea(warning = null),
+                    status = it
+                ),
+                dummyOfflineAreaItem(status = it)
+            )
+        }
+        .asSequence()
 }

--- a/app/src/main/res/drawable/ic_round_warning.xml
+++ b/app/src/main/res/drawable/ic_round_warning.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M4.47,21h15.06c1.54,0 2.5,-1.67 1.73,-3L13.73,4.99c-0.77,-1.33 -2.69,-1.33 -3.46,0L2.74,18c-0.77,1.33 0.19,3 1.73,3zM12,14c-0.55,0 -1,-0.45 -1,-1v-2c0,-0.55 0.45,-1 1,-1s1,0.45 1,1v2c0,0.55 -0.45,1 -1,1zM13,18h-2v-2h2v2z" />
+
+</vector>


### PR DESCRIPTION
We want users to be more aware of area warnings (example: hunting reserve, poor connectivity) when they are on the map.

<img src="https://github.com/boolder-org/boolder-android/assets/8343416/ab8eb651-8b45-4076-a9af-9145a8358f1b" width=300 />

Also, in the case of a poor connectivity, we want to make the area photos download button more visible.

|Before|After|
|-|-|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/8792c7a1-ff1a-48bc-8346-80deec6eaafd" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/35aea73b-b84a-4aa6-b7ba-1fd93aebf02b" width=300 />|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/0500a5ff-3631-497a-8d26-c7e0ea445e9e" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/ded3aeb3-bd39-4a97-87d9-dacc30d13c33" width=300 />|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/9b86eb1f-b546-44cb-a485-bf33f9994704" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/3008475a-abfc-42f7-ad4e-93e8d8242c26" width=300 />|

Resolves #103 