### PR TITLE
Handle deep links to boulder problem

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,8 +22,29 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <intent-filter
+                android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="www.boolder.com"
+                    android:pathPrefix="/en/p" />
+            </intent-filter>
+
+            <intent-filter
+                android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="www.boolder.com"
+                    android:pathPrefix="/fr/p" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/boolder/boolder/domain/model/Topo.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/model/Topo.kt
@@ -53,5 +53,6 @@ enum class TopoOrigin {
     MAP,
     SEARCH,
     TOPO,
-    CIRCUIT
+    CIRCUIT,
+    DEEP_LINK
 }

--- a/app/src/main/java/com/boolder/boolder/view/main/MainActivity.kt
+++ b/app/src/main/java/com/boolder/boolder/view/main/MainActivity.kt
@@ -1,9 +1,11 @@
 package com.boolder.boolder.view.main
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
+import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.boolder.boolder.R
@@ -20,14 +22,24 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
-        val navController = navHostFragment.navController
+        val navController = findNavController()
 
         binding.bottomNavigationView.setupWithNavController(navController)
 
         navController.addOnDestinationChangedListener { _, destination, _ ->
             binding.bottomNavigationView.isVisible = destination.id in BOTTOM_BAR_DESTINATION_IDS
         }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        findNavController().handleDeepLink(intent)
+    }
+
+    private fun findNavController(): NavController {
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+
+        return navHostFragment.navController
     }
 
     companion object {

--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -64,7 +64,6 @@ import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import java.lang.Double.max
 
-
 class MapFragment : Fragment(), BoolderMapListener {
 
     private var binding: FragmentMapBinding? = null
@@ -248,6 +247,10 @@ class MapFragment : Fragment(), BoolderMapListener {
 
             mapViewModel.onGradeRangeSelected(gradeRange)
         }
+
+        arguments?.getString("problem_id")?.toIntOrNull()?.let { problemId ->
+            mapViewModel.fetchTopo(problemId = problemId, origin = TopoOrigin.DEEP_LINK)
+        }
     }
 
     override fun onResume() {
@@ -427,7 +430,9 @@ class MapFragment : Fragment(), BoolderMapListener {
         val zoomLevel = binding.mapView.mapboxMap.cameraState.zoom
 
         val cameraOptions = CameraOptions.Builder().run {
-            if (origin in arrayOf(TopoOrigin.SEARCH, TopoOrigin.CIRCUIT)) center(point)
+            if (origin in arrayOf(TopoOrigin.SEARCH, TopoOrigin.CIRCUIT, TopoOrigin.DEEP_LINK)) {
+                center(point)
+            }
 
             padding(EdgeInsets(40.0, 0.0, binding.mapView.height / 2.0, 0.0))
             zoom(if (zoomLevel <= 19.0) 20.0 else zoomLevel)

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -10,6 +10,13 @@
         android:name="com.boolder.boolder.view.map.MapFragment"
         android:label="Map fragment"
         tools:layout="@layout/fragment_map">
+        <deepLink
+            app:action="android.intent.action.VIEW"
+            app:uri="https://www.boolder.com/en/p/{problem_id}" />
+        <deepLink
+            app:action="android.intent.action.VIEW"
+            app:uri="https://www.boolder.com/fr/p/{problem_id}" />
+
         <action
             android:id="@+id/navigate_to_search"
             app:destination="@+id/search_fragment"


### PR DESCRIPTION
Any shared link from a topo should be opened by the app if it installed on the device.

This change needs a preliminary setup of the backend, so that the association between the app and the `boolder.com` domain is legit:
https://github.com/boolder-org/boolder-rails/pull/34