### PR TITLE
Fix bug with multi lines

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/map/TopoDataAggregator.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/TopoDataAggregator.kt
@@ -110,6 +110,7 @@ class TopoDataAggregator(
                 it.id != mainProblem.id
                     && it.parentId == null
                     && it.id != mainProblem.parentId
+                    && lineRepository.loadByProblemId(it.id)?.topoId == topoId // todo: clean up once we handle ordering of multiple lines
             }
 
         val tickStatuses = problemsOnSameTopo.map { problemEntity ->


### PR DESCRIPTION
Boulder problems having multiple lines (traverses) could appear on topos where they were not starting.
This is fixed by checking that the first topo ID for a given problem is the same as the ID of the displayed topo.

|Before|After|
|-|-|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/4d4b5389-945c-465a-b081-c48ff84da2e1" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/8f07f23c-39c8-42e6-8281-11613c1eb143" width=300 />|

Resolves #108 