### PR TITLE
Fix broken links in unsupported locales

### DIFF
--- a/app/src/main/java/com/boolder/boolder/domain/Converter.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/Converter.kt
@@ -11,7 +11,7 @@ import com.boolder.boolder.domain.model.Area
 import com.boolder.boolder.domain.model.Line
 import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.domain.model.TickedProblem
-import java.util.Locale
+import com.boolder.boolder.utils.getLanguage
 
 fun ProblemEntity.convert(
     areaName: String? = null,
@@ -63,9 +63,11 @@ fun LineEntity.convert(): Line {
 }
 
 fun AreasEntity.convert(): Area {
-    val language = Locale.getDefault().language
-    val description = if (language == "fr") descriptionFr else descriptionEn
-    val warning = if (language == "fr") warningFr else warningEn
+    val (description, warning) = when (getLanguage()) {
+        "fr" -> descriptionFr to warningFr
+        else -> descriptionEn to warningEn
+    }
+
     val rawTags = tags?.split(",") ?: emptyList()
     val tags = rawTags.mapNotNull {
         when (it) {

--- a/app/src/main/java/com/boolder/boolder/utils/LocaleUtils.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/LocaleUtils.kt
@@ -1,0 +1,9 @@
+package com.boolder.boolder.utils
+
+import java.util.Locale
+
+fun getLanguage(): String =
+    when (Locale.getDefault().language) {
+        "fr" -> "fr"
+        else -> "en"
+    }

--- a/app/src/main/java/com/boolder/boolder/view/contribute/ContributeFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/contribute/ContributeFragment.kt
@@ -8,8 +8,8 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
+import com.boolder.boolder.utils.getLanguage
 import com.boolder.boolder.view.compose.BoolderTheme
-import java.util.Locale
 
 class ContributeFragment : Fragment() {
 
@@ -30,11 +30,11 @@ class ContributeFragment : Fragment() {
         }
 
     private fun onStartContributingClicked() {
-        openWebUrl("https://www.boolder.com/${getUrlLocale()}/contribute?dismiss_banner=true")
+        openWebUrl("https://www.boolder.com/${getLanguage()}/contribute?dismiss_banner=true")
     }
 
     private fun onLearnMoreClicked() {
-        openWebUrl("https://www.boolder.com/${getUrlLocale()}/about")
+        openWebUrl("https://www.boolder.com/${getLanguage()}/about")
     }
 
     private fun openWebUrl(url: String) {
@@ -42,7 +42,4 @@ class ContributeFragment : Fragment() {
 
         startActivity(intent)
     }
-
-    private fun getUrlLocale(): String =
-        if (Locale.getDefault().language == "fr") "fr" else "en"
 }

--- a/app/src/main/java/com/boolder/boolder/view/detail/TopoView.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/TopoView.kt
@@ -29,13 +29,13 @@ import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.domain.model.ProblemWithLine
 import com.boolder.boolder.domain.model.Topo
 import com.boolder.boolder.domain.model.toUiProblem
+import com.boolder.boolder.utils.getLanguage
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.detail.composable.CircuitControls
 import com.boolder.boolder.view.detail.composable.ProblemStartsLayer
 import com.boolder.boolder.view.detail.composable.TopoFooter
 import com.boolder.boolder.view.detail.uimodel.UiProblem
 import com.boolder.boolder.view.ticklist.TickedProblemSaver
-import java.util.Locale
 
 class TopoView(
     context: Context,
@@ -240,7 +240,7 @@ class TopoView(
             action = Intent.ACTION_SEND
             putExtra(
                 Intent.EXTRA_TEXT,
-                "https://www.boolder.com/${Locale.getDefault().language}/p/$problemId"
+                "https://www.boolder.com/${getLanguage()}/p/$problemId"
             )
             type = "text/plain"
         }

--- a/app/src/main/java/com/boolder/boolder/view/detail/composable/TopoFooter.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/composable/TopoFooter.kt
@@ -42,10 +42,10 @@ import com.boolder.boolder.R
 import com.boolder.boolder.data.userdatabase.entity.TickStatus
 import com.boolder.boolder.domain.model.Problem
 import com.boolder.boolder.domain.model.Steepness
+import com.boolder.boolder.utils.getLanguage
 import com.boolder.boolder.utils.previewgenerator.dummyProblem
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.compose.BoolderYellow
-import java.util.Locale
 
 @Composable
 fun TopoFooter(
@@ -63,7 +63,7 @@ fun TopoFooter(
         verticalArrangement = spacedBy(8.dp)
     ) {
         TopoFooterTitleRow(
-            problemName = if (Locale.getDefault().language == "fr") {
+            problemName = if (getLanguage() == "fr") {
                 problem.name.orEmpty()
             } else {
                 problem.nameEn.orEmpty()

--- a/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverFragment.kt
@@ -10,9 +10,9 @@ import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
+import com.boolder.boolder.utils.getLanguage
 import com.boolder.boolder.view.compose.BoolderTheme
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import java.util.Locale
 
 class DiscoverFragment : Fragment() {
 
@@ -54,7 +54,7 @@ class DiscoverFragment : Fragment() {
     }
 
     private fun openBeginnerGuideArticle() {
-        openWebUrl("https://www.boolder.com/${getUrlLocale()}/articles/beginners-guide")
+        openWebUrl("https://www.boolder.com/${getLanguage()}/articles/beginners-guide")
     }
 
     private fun onAreaClicked(areaId: Int) {
@@ -71,7 +71,7 @@ class DiscoverFragment : Fragment() {
     }
 
     private fun onOpenContributeWebPage() {
-        openWebUrl("https://www.boolder.com/${getUrlLocale()}/contribute")
+        openWebUrl("https://www.boolder.com/${getLanguage()}/contribute")
     }
 
     private fun openWebUrl(url: String) {
@@ -79,7 +79,4 @@ class DiscoverFragment : Fragment() {
 
         startActivity(intent)
     }
-
-    private fun getUrlLocale(): String =
-        if (Locale.getDefault().language == "fr") "fr" else "en"
 }

--- a/app/src/test/java/com/boolder/boolder/utils/LocaleUtilsTest.kt
+++ b/app/src/test/java/com/boolder/boolder/utils/LocaleUtilsTest.kt
@@ -1,0 +1,56 @@
+package com.boolder.boolder.utils
+
+import org.junit.After
+import org.junit.Test
+import java.util.Locale
+import kotlin.test.assertTrue
+
+class LocaleUtilsTest {
+
+    private val defaultLocale = Locale.getDefault()
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    @Test
+    fun `getLanguage() should return fr`() {
+        // Given
+        val locales = listOf(
+            Locale.FRANCE,
+            Locale.CANADA_FRENCH
+        )
+
+        // When
+        val languageCodes = locales.map {
+            Locale.setDefault(it)
+            getLanguage()
+        }
+
+        // Then
+        assertTrue(languageCodes.all { it == "fr" })
+    }
+
+    @Test
+    fun `getLanguage() should return en`() {
+        // Given
+        val locales = listOf(
+            Locale.UK,
+            Locale.US,
+            Locale.GERMANY,
+            Locale.ITALIAN,
+            Locale("nl", "NL"),
+            Locale("es", "ES")
+        )
+
+        // When
+        val languageCodes = locales.map {
+            Locale.setDefault(it)
+            getLanguage()
+        }
+
+        // Then
+        assertTrue(languageCodes.all { it == "en" })
+    }
+}


### PR DESCRIPTION
When sharing a link on a device set up with a different language than english or french, the generated link would not target any real address as only `en` or `fr` are accepted as locales in the website's URLs.

This commit defaults link generation to the english locale if the device is set up in a different language than french.

https://github.com/boolder-org/boolder-android/assets/8343416/9cded590-ae0c-4d46-89d5-0008fcd9bad9

Resolves #119 