### PR TITLE
Implement full screen photo feature

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
 
     // Coil
     implementation("io.coil-kt:coil:2.6.0")
+    implementation("io.coil-kt:coil-compose:2.6.0")
 
     // Jetpack compose
     val composeBom = platform("androidx.compose:compose-bom:2024.05.00")
@@ -111,9 +112,14 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
     implementation("com.google.android.material:material:1.12.0")
+
     testImplementation("io.insert-koin:koin-test-junit4:3.5.6")
     testImplementation("org.mockito:mockito-core:5.12.0")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.3.1")
+    testImplementation("app.cash.turbine:turbine:1.1.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     testImplementation("junit:junit:4.13.2")
+
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
 
     // Work manager

--- a/app/src/main/java/com/boolder/boolder/data/database/dao/LineDao.kt
+++ b/app/src/main/java/com/boolder/boolder/data/database/dao/LineDao.kt
@@ -7,9 +7,6 @@ import com.boolder.boolder.data.database.entity.LineEntity
 @Dao
 interface LineDao {
 
-    @Query("SELECT * FROM lines")
-    suspend fun getAll(): List<LineEntity>
-
     @Query("SELECT * FROM lines WHERE topo_id = :topoId")
     suspend fun loadByTopoId(topoId: Int): List<LineEntity>
 

--- a/app/src/main/java/com/boolder/boolder/data/database/repository/LineRepository.kt
+++ b/app/src/main/java/com/boolder/boolder/data/database/repository/LineRepository.kt
@@ -7,10 +7,6 @@ class LineRepository(
     private val lineDao: LineDao
 ) {
 
-    suspend fun getAll(): List<LineEntity> {
-        return lineDao.getAll()
-    }
-
     suspend fun loadAllByTopoIds(topoId: Int): List<LineEntity> {
         return lineDao.loadByTopoId(topoId)
     }

--- a/app/src/main/java/com/boolder/boolder/domain/model/Line.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/model/Line.kt
@@ -6,23 +6,22 @@ import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.json.Json
 
 @Parcelize
-class Line(
+data class Line(
     val id: Int,
     val problemId: Int,
     val topoId: Int,
     val coordinates: String?
 ) : Parcelable {
 
-    fun coordinatesParsed(): List<Coordinates> {
-        val joke = coordinates?.contains("null") == true
-        val isNotEmpty = !coordinates.isNullOrBlank()
-        return if (isNotEmpty && !joke) {
-            Json.decodeFromString(coordinates!!) as List<Coordinates>
-        } else emptyList()
-    }
-
     fun points(): List<PointD> {
         // Convert point to Double to avoid loose digit
-        return coordinatesParsed().map { PointD(it.x, it.y) }
+        return decodedCoordinates().map { PointD(it.x, it.y) }
+    }
+
+    private fun decodedCoordinates(): List<Coordinates> {
+        if (coordinates.isNullOrBlank()) return emptyList()
+        if ("null" in coordinates) return emptyList()
+
+        return Json.decodeFromString(coordinates) as List<Coordinates>
     }
 }

--- a/app/src/main/java/com/boolder/boolder/view/ViewModules.kt
+++ b/app/src/main/java/com/boolder/boolder/view/ViewModules.kt
@@ -12,6 +12,7 @@ import com.boolder.boolder.view.discover.driesfast.DriesFastViewModel
 import com.boolder.boolder.view.discover.levels.LevelsViewModel
 import com.boolder.boolder.view.discover.levels.beginner.BeginnerLevelsViewModel
 import com.boolder.boolder.view.discover.trainandbike.TrainAndBikeViewModel
+import com.boolder.boolder.view.fullscreenphoto.FullScreenPhotoViewModel
 import com.boolder.boolder.view.map.MapViewModel
 import com.boolder.boolder.view.map.TopoDataAggregator
 import com.boolder.boolder.view.map.filter.grade.GradesFilterViewModel
@@ -51,4 +52,6 @@ val viewModelModule = module {
     viewModelOf(::TrainAndBikeViewModel)
 
     viewModelOf(::TickListViewModel)
+
+    viewModelOf(::FullScreenPhotoViewModel)
 }

--- a/app/src/main/java/com/boolder/boolder/view/detail/composable/ProblemLine.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/composable/ProblemLine.kt
@@ -39,7 +39,8 @@ import com.boolder.boolder.view.detail.PointD
 internal fun ProblemLine(
     line: Line?,
     color: Color,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    scaleFactor: Float = 1f
 ) {
     val points = line?.points() ?: return
 
@@ -83,7 +84,7 @@ internal fun ProblemLine(
                     path = path,
                     color = internalColor,
                     style = Stroke(
-                        width = 4.dp.toPx(),
+                        width = (4.dp * scaleFactor).toPx(),
                         cap = StrokeCap.Round,
                         join = StrokeJoin.Round,
                         pathEffect = PathEffect.dashPathEffect(

--- a/app/src/main/java/com/boolder/boolder/view/fullscreenphoto/FullScreenPhotoFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/fullscreenphoto/FullScreenPhotoFragment.kt
@@ -1,0 +1,36 @@
+package com.boolder.boolder.view.fullscreenphoto
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.fragment.findNavController
+import com.boolder.boolder.view.compose.BoolderTheme
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class FullScreenPhotoFragment : Fragment() {
+
+    private val viewModel by viewModel<FullScreenPhotoViewModel>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View =
+        ComposeView(inflater.context).apply {
+            setContent {
+                val screenState by viewModel.screenState.collectAsStateWithLifecycle()
+
+                BoolderTheme {
+                    FullScreenPhotoScreen(
+                        screenState = screenState,
+                        onCloseClicked = { findNavController().popBackStack() }
+                    )
+                }
+            }
+        }
+}

--- a/app/src/main/java/com/boolder/boolder/view/fullscreenphoto/FullScreenPhotoFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/fullscreenphoto/FullScreenPhotoFragment.kt
@@ -5,16 +5,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.fragment.findNavController
 import com.boolder.boolder.view.compose.BoolderTheme
+import com.boolder.boolder.view.custom.EdgeToEdgeBottomSheetDialogFragment
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class FullScreenPhotoFragment : Fragment() {
+class FullScreenPhotoFragment : EdgeToEdgeBottomSheetDialogFragment() {
 
     private val viewModel by viewModel<FullScreenPhotoViewModel>()
+
+    private val scrollOffsetState = mutableFloatStateOf(1f)
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -24,13 +30,41 @@ class FullScreenPhotoFragment : Fragment() {
         ComposeView(inflater.context).apply {
             setContent {
                 val screenState by viewModel.screenState.collectAsStateWithLifecycle()
+                val scrollOffset by remember { scrollOffsetState }
 
                 BoolderTheme {
                     FullScreenPhotoScreen(
                         screenState = screenState,
-                        onCloseClicked = { findNavController().popBackStack() }
+                        scrollOffset = scrollOffset,
+                        onCloseClicked = ::onCloseClicked,
+                        onDragStateChanged = ::onDragStateChanged
                     )
                 }
             }
         }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        (dialog as? BottomSheetDialog)?.behavior?.apply {
+            skipCollapsed = true
+            state = BottomSheetBehavior.STATE_EXPANDED
+
+            addBottomSheetCallback(object : BottomSheetCallback() {
+                override fun onStateChanged(bottomSheet: View, newState: Int) {}
+
+                override fun onSlide(bottomSheet: View, slideOffset: Float) {
+                    scrollOffsetState.floatValue = .5f + .5f * slideOffset
+                }
+            })
+        }
+    }
+
+    private fun onCloseClicked() {
+        (dialog as? BottomSheetDialog)?.behavior?.state = BottomSheetBehavior.STATE_HIDDEN
+    }
+
+    private fun onDragStateChanged(canDragParentContainer: Boolean) {
+        (dialog as? BottomSheetDialog)?.behavior?.isDraggable = canDragParentContainer
+    }
 }

--- a/app/src/main/java/com/boolder/boolder/view/fullscreenphoto/FullScreenPhotoScreen.kt
+++ b/app/src/main/java/com/boolder/boolder/view/fullscreenphoto/FullScreenPhotoScreen.kt
@@ -1,0 +1,205 @@
+package com.boolder.boolder.view.fullscreenphoto
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.animateOffsetAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.boolder.boolder.R
+import com.boolder.boolder.domain.model.toUiProblem
+import com.boolder.boolder.utils.previewgenerator.dummyCompleteProblem
+import com.boolder.boolder.view.compose.BoolderTheme
+import com.boolder.boolder.view.compose.LoadingScreen
+import com.boolder.boolder.view.detail.composable.ProblemStartsLayer
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+@Composable
+internal fun FullScreenPhotoScreen(
+    screenState: FullScreenPhotoViewModel.ScreenState,
+    onCloseClicked: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center
+    ) {
+        when (screenState) {
+            is FullScreenPhotoViewModel.ScreenState.Loading -> LoadingScreen(
+                modifier = modifier.background(color = MaterialTheme.colorScheme.background)
+            )
+
+            is FullScreenPhotoViewModel.ScreenState.Content -> FullScreenPhotoScreenContent(
+                screenState = screenState
+            )
+
+            is FullScreenPhotoViewModel.ScreenState.Error -> FullScreenPhotoScreenError()
+        }
+
+        IconButton(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .statusBarsPadding()
+                .padding(8.dp),
+            onClick = onCloseClicked
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_close),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onBackground
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun FullScreenPhotoScreenContent(
+    screenState: FullScreenPhotoViewModel.ScreenState.Content
+) {
+    val widthPx = with(LocalDensity.current) {
+        (LocalConfiguration.current.screenWidthDp * density).roundToInt()
+    }
+    val heightPx = (widthPx * 3f / 4f).roundToInt()
+
+    val uiProblem = screenState.completeProblem.toUiProblem(
+        containerWidthPx = widthPx,
+        containerHeightPx = heightPx
+    )
+
+    var targetOffset by remember { mutableStateOf(Offset.Zero) }
+    val offset by animateOffsetAsState(
+        targetValue = targetOffset,
+        label = "photo_offset_animation"
+    )
+
+    var targetScaleFactor by remember { mutableFloatStateOf(1f) }
+    val scaleFactor by animateFloatAsState(
+        targetValue = targetScaleFactor,
+        label = "photo_scale_animation"
+    )
+
+    AsyncImage(
+        modifier = Modifier
+            .fillMaxWidth()
+            .offset { IntOffset(x = offset.x.roundToInt(), y = offset.y.roundToInt()) }
+            .graphicsLayer {
+                scaleX = scaleFactor
+                scaleY = scaleFactor
+            }
+            .transformable(
+                state = rememberTransformableState { zoomChange, panChange, _ ->
+                    targetScaleFactor = max(targetScaleFactor * zoomChange, 1f)
+
+                    val rawOffset = targetOffset + (panChange * targetScaleFactor)
+                    val scaleDeltaX = ((widthPx * targetScaleFactor) - widthPx) / 2f
+                    val scaleDeltaY = ((heightPx * targetScaleFactor) - heightPx) / 2f
+
+                    targetOffset = Offset(
+                        x = rawOffset.x.coerceIn(-scaleDeltaX..scaleDeltaX),
+                        y = rawOffset.y.coerceIn(-scaleDeltaY..scaleDeltaY)
+                    )
+                }
+            )
+            .combinedClickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = {},
+                onDoubleClick = {
+                    targetScaleFactor = if (targetScaleFactor == 1f) 2.5f else 1f
+                    targetOffset = Offset.Zero
+                }
+            ),
+        model = screenState.photoUri,
+        placeholder = if (LocalInspectionMode.current) painterResource(id = R.drawable.area_cover_1) else null,
+        contentDescription = null,
+        contentScale = ContentScale.Fit
+    )
+
+    ProblemStartsLayer(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(4 / 3f)
+            .offset { IntOffset(x = offset.x.roundToInt(), y = offset.y.roundToInt()) }
+            .graphicsLayer {
+                scaleX = scaleFactor
+                scaleY = scaleFactor
+            },
+        uiProblems = listOf(uiProblem),
+        selectedProblem = uiProblem.completeProblem,
+        onProblemStartClicked = {},
+        onVariantSelected = {}
+    )
+}
+
+@Composable
+private fun FullScreenPhotoScreenError() {
+    Text(
+        modifier = Modifier.padding(24.dp),
+        text = stringResource(id = R.string.full_screen_photo_error),
+        color = MaterialTheme.colorScheme.onBackground
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun FullScreenPhotoScreenPreview(
+    @PreviewParameter(FullScreenPhotoScreenPreviewParameterProvider::class)
+    screenState: FullScreenPhotoViewModel.ScreenState
+) {
+    BoolderTheme {
+        FullScreenPhotoScreen(
+            screenState = screenState,
+            onCloseClicked = {}
+        )
+    }
+}
+
+private class FullScreenPhotoScreenPreviewParameterProvider : PreviewParameterProvider<FullScreenPhotoViewModel.ScreenState> {
+    override val values = sequenceOf(
+        FullScreenPhotoViewModel.ScreenState.Loading,
+        FullScreenPhotoViewModel.ScreenState.Content(
+            photoUri = "photoUri",
+            completeProblem = dummyCompleteProblem()
+        ),
+        FullScreenPhotoViewModel.ScreenState.Error
+    )
+}

--- a/app/src/main/java/com/boolder/boolder/view/fullscreenphoto/FullScreenPhotoViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/fullscreenphoto/FullScreenPhotoViewModel.kt
@@ -1,0 +1,67 @@
+package com.boolder.boolder.view.fullscreenphoto
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.boolder.boolder.data.database.repository.LineRepository
+import com.boolder.boolder.data.database.repository.ProblemRepository
+import com.boolder.boolder.domain.convert
+import com.boolder.boolder.domain.model.CompleteProblem
+import com.boolder.boolder.domain.model.ProblemWithLine
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class FullScreenPhotoViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val lineRepository: LineRepository,
+    private val problemRepository: ProblemRepository
+) : ViewModel() {
+
+    private val problemId = requireNotNull(savedStateHandle.get<Int>("problem_id"))
+    private val photoUri = requireNotNull(savedStateHandle.get<String>("photo_uri"))
+
+    private val _screenState = MutableStateFlow<ScreenState>(ScreenState.Loading)
+    val screenState = _screenState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val problem = problemRepository.problemById(problemId)
+                ?.convert()
+                ?: run {
+                    _screenState.update { ScreenState.Error }
+                    return@launch
+                }
+
+            val line = lineRepository.loadByProblemId(problemId)
+                ?.convert()
+
+            val completeProblem = CompleteProblem(
+                problemWithLine = ProblemWithLine(
+                    problem = problem,
+                    line = line
+                ),
+                variants = emptyList()
+            )
+
+            _screenState.update {
+                ScreenState.Content(
+                    photoUri = photoUri,
+                    completeProblem = completeProblem
+                )
+            }
+        }
+    }
+
+    sealed interface ScreenState {
+        data object Loading : ScreenState
+
+        data class Content(
+            val photoUri: String,
+            val completeProblem: CompleteProblem
+        ) : ScreenState
+
+        data object Error : ScreenState
+    }
+}

--- a/app/src/main/java/com/boolder/boolder/view/map/MapState.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapState.kt
@@ -1,7 +1,0 @@
-package com.boolder.boolder.view.map
-
-data class MapState(
-    val centerLongitude: Double,
-    val centerLatitude: Double,
-    val zoom: Double
-)

--- a/app/src/main/java/com/boolder/boolder/view/map/MapViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapViewModel.kt
@@ -24,6 +24,7 @@ import com.boolder.boolder.view.map.filter.FiltersEventHandler
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
 import com.boolder.boolder.view.ticklist.TickedProblemSaver
+import com.mapbox.maps.CameraState
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -75,7 +76,7 @@ class MapViewModel(
     private var lastZoomValue = 0.0
     private var isProblemTopoShown = false
 
-    var mapState: MapState? = null
+    var cameraState: CameraState? = null
 
     fun fetchTopo(problemId: Int, origin: TopoOrigin) {
         viewModelScope.launch {

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -201,7 +201,7 @@
         android:name="com.boolder.boolder.view.contribute.ContributeFragment"
         android:label="Contribute" />
 
-    <fragment
+    <dialog
         android:id="@+id/full_screen_photo_fragment"
         android:name="com.boolder.boolder.view.fullscreenphoto.FullScreenPhotoFragment"
         android:label="Full screen photo">
@@ -211,7 +211,7 @@
         <argument
             android:name="photo_uri"
             app:argType="string" />
-    </fragment>
+    </dialog>
 
     <dialog
         android:id="@+id/dialog_circuit_filter"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -36,6 +36,9 @@
         <action
             android:id="@+id/show_poi"
             app:destination="@+id/dialog_poi" />
+        <action
+            android:id="@+id/show_problem_photo_full_screen"
+            app:destination="@+id/full_screen_photo_fragment" />
     </fragment>
 
     <fragment
@@ -197,6 +200,18 @@
         android:id="@+id/contribute_fragment"
         android:name="com.boolder.boolder.view.contribute.ContributeFragment"
         android:label="Contribute" />
+
+    <fragment
+        android:id="@+id/full_screen_photo_fragment"
+        android:name="com.boolder.boolder.view.fullscreenphoto.FullScreenPhotoFragment"
+        android:label="Full screen photo">
+        <argument
+            android:name="problem_id"
+            app:argType="integer" />
+        <argument
+            android:name="photo_uri"
+            app:argType="string" />
+    </fragment>
 
     <dialog
         android:id="@+id/dialog_circuit_filter"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -151,7 +151,7 @@
     <string name="contribute_cta">Commencer à contribuer</string>
     <string name="contribute_learn_more">En savoir plus sur Boolder</string>
 
-    <string name="full_screen_photo_error">Ce bloc ne peut être affiché</string>
+    <string name="full_screen_photo_error">Cette photo ne peut être affichée</string>
 
     <string name="cd_circuit_previous_boulder_problem">Bloc précédent du circuit</string>
     <string name="cd_circuit_next_boulder_problem">Bloc suivant du circuit</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -151,6 +151,8 @@
     <string name="contribute_cta">Commencer à contribuer</string>
     <string name="contribute_learn_more">En savoir plus sur Boolder</string>
 
+    <string name="full_screen_photo_error">Ce bloc ne peut être affiché</string>
+
     <string name="cd_circuit_previous_boulder_problem">Bloc précédent du circuit</string>
     <string name="cd_circuit_next_boulder_problem">Bloc suivant du circuit</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,6 +154,8 @@
     <string name="contribute_cta">Start contributing</string>
     <string name="contribute_learn_more">Learn more about Boolder</string>
 
+    <string name="full_screen_photo_error">This boulder problem can\'t be displayed</string>
+
     <string name="cd_circuit_previous_boulder_problem">Circuit\'s previous boulder problem</string>
     <string name="cd_circuit_next_boulder_problem">Circuit\'s next boulder problem</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,7 +154,7 @@
     <string name="contribute_cta">Start contributing</string>
     <string name="contribute_learn_more">Learn more about Boolder</string>
 
-    <string name="full_screen_photo_error">This boulder problem can\'t be displayed</string>
+    <string name="full_screen_photo_error">This photo can\'t be displayed</string>
 
     <string name="cd_circuit_previous_boulder_problem">Circuit\'s previous boulder problem</string>
     <string name="cd_circuit_next_boulder_problem">Circuit\'s next boulder problem</string>

--- a/app/src/test/java/com/boolder/boolder/view/fullscreenphoto/FullScreenPhotoViewModelTest.kt
+++ b/app/src/test/java/com/boolder/boolder/view/fullscreenphoto/FullScreenPhotoViewModelTest.kt
@@ -1,0 +1,158 @@
+package com.boolder.boolder.view.fullscreenphoto
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.boolder.boolder.data.database.entity.LineEntity
+import com.boolder.boolder.data.database.entity.ProblemEntity
+import com.boolder.boolder.data.database.repository.LineRepository
+import com.boolder.boolder.data.database.repository.ProblemRepository
+import com.boolder.boolder.domain.model.CompleteProblem
+import com.boolder.boolder.domain.model.Line
+import com.boolder.boolder.domain.model.Problem
+import com.boolder.boolder.domain.model.ProblemWithLine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+@RunWith(MockitoJUnitRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class FullScreenPhotoViewModelTest {
+
+    @Mock private lateinit var savedStateHandle: SavedStateHandle
+    @Mock private lateinit var lineRepository: LineRepository
+    @Mock private lateinit var problemRepository: ProblemRepository
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Default)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `viewModel should emit a Content state`() = runTest {
+        // Given
+        val viewModel = viewModelWithMocking {
+            doReturn(666).whenever(savedStateHandle).get<Int>("problem_id")
+            doReturn("https://www.boolder.com/en/photo/666.png").whenever(savedStateHandle).get<String>("photo_uri")
+            doReturn(PROBLEM_ENTITY).whenever(problemRepository).problemById(666)
+            doReturn(LINE_ENTITY).whenever(lineRepository).loadByProblemId(666)
+        }
+
+        // When
+        viewModel.screenState.test {
+
+            // Then
+            val contentState = FullScreenPhotoViewModel.ScreenState.Content(
+                photoUri = "https://www.boolder.com/en/photo/666.png",
+                completeProblem = CompleteProblem(
+                    problemWithLine = ProblemWithLine(
+                        problem = PROBLEM,
+                        line = LINE
+                    ),
+                    variants = emptyList()
+                )
+            )
+
+            assertEquals(FullScreenPhotoViewModel.ScreenState.Loading, awaitItem())
+            assertEquals(contentState, awaitItem())
+        }
+    }
+
+    @Test
+    fun `viewModel should emit an Error state`() = runTest {
+        // Given
+        val viewModel = viewModelWithMocking {
+            doReturn(666).whenever(savedStateHandle).get<Int>("problem_id")
+            doReturn("https://www.boolder.com/en/photo/666.png").whenever(savedStateHandle).get<String>("photo_uri")
+            doReturn(null).whenever(problemRepository).problemById(666)
+        }
+
+        // When
+        viewModel.screenState.test {
+
+            // Then
+            assertEquals(FullScreenPhotoViewModel.ScreenState.Error, awaitItem())
+        }
+    }
+
+    private suspend fun viewModelWithMocking(block: suspend () -> Unit): FullScreenPhotoViewModel {
+        block()
+
+        return FullScreenPhotoViewModel(
+            savedStateHandle = savedStateHandle,
+            lineRepository = lineRepository,
+            problemRepository = problemRepository
+        )
+    }
+
+    companion object {
+        private val PROBLEM_ENTITY = ProblemEntity(
+            id = 666,
+            name = "Dummy",
+            nameEn = "Dummy",
+            nameSearchable = "dummy",
+            grade = "4",
+            latitude = 0f,
+            longitude = 0f,
+            circuitId = null,
+            circuitNumber = null,
+            circuitColor = null,
+            steepness = "wall",
+            sitStart = false,
+            areaId = 1,
+            bleauInfoId = null,
+            featured = false,
+            popularity = null,
+            parentId = null
+        )
+
+        private val PROBLEM = Problem(
+            id = 666,
+            name = "Dummy",
+            nameEn = "Dummy",
+            grade = "4",
+            latitude = 0f,
+            longitude = 0f,
+            circuitId = null,
+            circuitNumber = null,
+            circuitColor = null,
+            steepness = "wall",
+            sitStart = false,
+            areaId = 1,
+            bleauInfoId = null,
+            featured = false,
+            parentId = null,
+            areaName = null,
+            tickStatus = null
+        )
+
+        private val LINE_ENTITY = LineEntity(
+            id = 345,
+            problemId = 666,
+            topoId = 123,
+            coordinates = null
+        )
+
+        private val LINE = Line(
+            id = 345,
+            problemId = 666,
+            topoId = 123,
+            coordinates = null
+        )
+    }
+}


### PR DESCRIPTION
The possibility to see a topo photo in full screen mode and zoom on it has been available in the iOS app for a long time, but still was not implemented in the android app.

https://github.com/boolder-org/boolder-android/assets/8343416/6c26b71d-31b8-4c1d-a6a4-9e8f11812e1a

The image can be zoomed by a pinch gesture or by a double tap.

Also, in the case of a missing boulder problem (highly unlikely, as the full screen photo has to be accessed from the topo of an already existing boulder problem), the following message will be shown:

<img src="https://github.com/boolder-org/boolder-android/assets/8343416/db98007d-5a37-4c62-9866-ecb900518ea7" width=300 />

Resolves #21 