### PR TITLE
Fix map camera after a search

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 
     //Mapbox
-    implementation("com.mapbox.maps:android:11.3.1")
+    implementation("com.mapbox.maps:android:11.4.0")
 
     // Play Services
     implementation("com.google.android.gms:play-services-location:21.2.0")

--- a/app/src/main/java/com/boolder/boolder/data/database/repository/CircuitRepository.kt
+++ b/app/src/main/java/com/boolder/boolder/data/database/repository/CircuitRepository.kt
@@ -5,7 +5,6 @@ import com.boolder.boolder.data.database.entity.CircuitEntity
 import com.boolder.boolder.domain.model.Circuit
 import com.boolder.boolder.domain.model.CircuitColor
 import com.mapbox.geojson.Point
-import com.mapbox.maps.CoordinateBounds
 
 class CircuitRepository(
     private val circuitDao: CircuitDao
@@ -35,7 +34,7 @@ class CircuitRepository(
         averageGrade = averageGrade,
         isBeginnerFriendly = beginnerFriendly,
         isDangerous = dangerous,
-        coordinateBounds = CoordinateBounds(
+        coordinateBounds = listOf(
             Point.fromLngLat(southWestLng, southWestLat),
             Point.fromLngLat(northEastLng, northEastLat)
         )

--- a/app/src/main/java/com/boolder/boolder/domain/model/Circuit.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/model/Circuit.kt
@@ -1,7 +1,7 @@
 package com.boolder.boolder.domain.model
 
 import android.os.Parcelable
-import com.mapbox.maps.CoordinateBounds
+import com.mapbox.geojson.Point
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -11,5 +11,5 @@ data class Circuit(
     val averageGrade: String,
     val isBeginnerFriendly: Boolean,
     val isDangerous: Boolean,
-    val coordinateBounds: CoordinateBounds
+    val coordinateBounds: List<Point>
 ) : Parcelable

--- a/app/src/main/java/com/boolder/boolder/utils/previewgenerator/CircuitGenerator.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/previewgenerator/CircuitGenerator.kt
@@ -3,7 +3,6 @@ package com.boolder.boolder.utils.previewgenerator
 import com.boolder.boolder.domain.model.Circuit
 import com.boolder.boolder.domain.model.CircuitColor
 import com.mapbox.geojson.Point
-import com.mapbox.maps.CoordinateBounds
 
 fun dummyCircuit(
     id: Int = 0,
@@ -15,7 +14,7 @@ fun dummyCircuit(
     averageGrade = averageGrade,
     isBeginnerFriendly = false,
     isDangerous = false,
-    coordinateBounds = CoordinateBounds(
+    coordinateBounds = listOf(
         Point.fromLngLat(0.0, 0.0),
         Point.fromLngLat(0.0, 0.0)
     )

--- a/app/src/main/java/com/boolder/boolder/view/compose/CircuitItem.kt
+++ b/app/src/main/java/com/boolder/boolder/view/compose/CircuitItem.kt
@@ -27,7 +27,6 @@ import com.boolder.boolder.domain.model.Circuit
 import com.boolder.boolder.domain.model.CircuitColor
 import com.boolder.boolder.utils.extension.composeColor
 import com.mapbox.geojson.Point
-import com.mapbox.maps.CoordinateBounds
 
 @Composable
 internal fun CircuitItem(
@@ -108,7 +107,7 @@ private class CircuitItemPreviewParameterProvider : PreviewParameterProvider<Cir
                 averageGrade = "${index + 1}a",
                 isBeginnerFriendly = index == 0,
                 isDangerous = index == 8,
-                coordinateBounds = CoordinateBounds(
+                coordinateBounds = listOf(
                     Point.fromLngLat(0.0, 0.0),
                     Point.fromLngLat(0.0, 0.0)
                 )

--- a/app/src/main/java/com/boolder/boolder/view/map/filter/circuit/CircuitFilterLayout.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/filter/circuit/CircuitFilterLayout.kt
@@ -39,7 +39,6 @@ import com.boolder.boolder.view.compose.BoolderRippleTheme
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.compose.CircuitItem
 import com.mapbox.geojson.Point
-import com.mapbox.maps.CoordinateBounds
 
 @Composable
 fun CircuitFilterLayout(
@@ -195,7 +194,7 @@ private class CircuitFilterLayoutPreviewParameterProvider : PreviewParameterProv
                 averageGrade = "${index + 1}a",
                 isBeginnerFriendly = index == 0,
                 isDangerous = index == 8,
-                coordinateBounds = CoordinateBounds(
+                coordinateBounds = listOf(
                     Point.fromLngLat(0.0, 0.0),
                     Point.fromLngLat(0.0, 0.0)
                 )

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -8,8 +8,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.boolder.boolder.view.map.BoolderMap
-            android:id="@+id/mapView"
+        <FrameLayout
+            android:id="@+id/map_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.4.0' apply false
-    id 'com.android.library' version '8.4.0' apply false
+    id 'com.android.application' version '8.4.1' apply false
+    id 'com.android.library' version '8.4.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.23' apply false
     id 'com.google.devtools.ksp' version "1.9.23-1.0.20" apply false


### PR DESCRIPTION
Sometimes after a search, the map camera was positioned in the wrong place due to a race condition between the previous camera position being restored after the search result location was displayed:

https://github.com/boolder-org/boolder-android/assets/8343416/66bcd569-3c27-4b2b-92bd-3e10b0593658

This behavior has been fixed by changing the way the `MapView` is initialized. Before, it was instantiated through the XML layout file, then the position was restored, and if no race condition issue was showing up, then the search result location was shown. Now it is instantiated programmatically with the previous position being passed as the default position when initializing, then the search result location is applied, avoiding the race condition issue. This also avoid the flickering that could be seen before

https://github.com/boolder-org/boolder-android/assets/8343416/94f22fa3-77d6-4bbc-ad8a-9300838734fa
