### PR TITLE
Fix navigation crashes when spamming clicks

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewFragment.kt
@@ -60,15 +60,23 @@ class AreaOverviewFragment : Fragment() {
     }
 
     private fun onAreaProblemsCountClicked() {
+        val navController = findNavController()
+
+        if (navController.currentDestination?.id == R.id.area_problems_fragment) return
+
         val direction = AreaOverviewFragmentDirections.navigateToAreaProblemsScreen(areaId = args.areaId)
 
-        findNavController().navigate(direction)
+        navController.navigate(direction)
     }
 
     private fun onCircuitClicked(circuitId: Int) {
+        val navController = findNavController()
+
+        if (navController.currentDestination?.id == R.id.area_circuit_fragment) return
+
         val direction = AreaOverviewFragmentDirections.navigateToAreaCircuitScreen(circuitId = circuitId)
 
-        findNavController().navigate(direction)
+        navController.navigate(direction)
     }
 
     private fun onPoiClicked(googleMapsUrl: String) {

--- a/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverFragment.kt
@@ -10,6 +10,7 @@ import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
+import com.boolder.boolder.R
 import com.boolder.boolder.utils.getLanguage
 import com.boolder.boolder.view.compose.BoolderTheme
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -40,6 +41,15 @@ class DiscoverFragment : Fragment() {
         }
 
     private fun onDiscoverHeaderItemClicked(item: DiscoverHeaderItem) {
+        val navController = findNavController()
+        val targetDestinationIds = arrayOf(
+            R.id.levels_fragment,
+            R.id.dries_fast_fragment,
+            R.id.train_and_bike_fragment
+        )
+
+        if (navController.currentDestination?.id in targetDestinationIds) return
+
         val direction = when (item) {
             DiscoverHeaderItem.BEGINNER_GUIDE -> {
                 openBeginnerGuideArticle()
@@ -50,7 +60,7 @@ class DiscoverFragment : Fragment() {
             DiscoverHeaderItem.TRAIN_AND_BIKE -> DiscoverFragmentDirections.navigateToTrainAndBikeScreen()
         }
 
-        findNavController().navigate(direction)
+        navController.navigate(direction)
     }
 
     private fun openBeginnerGuideArticle() {
@@ -58,12 +68,16 @@ class DiscoverFragment : Fragment() {
     }
 
     private fun onAreaClicked(areaId: Int) {
+        val navController = findNavController()
+
+        if (navController.currentDestination?.id == R.id.area_overview_fragment) return
+
         val direction = DiscoverFragmentDirections.navigateToAreaOverviewScreen(
             areaId = areaId,
             displayShowOnMapButton = true
         )
 
-        findNavController().navigate(direction)
+        navController.navigate(direction)
     }
 
     private fun onOpenPlayStorePage() {

--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -443,24 +443,36 @@ class MapFragment : Fragment(), BoolderMapListener {
     private fun navigateToAreaOverviewScreen(areaId: Int?) {
         areaId ?: return
 
+        val navController = findNavController()
+
+        if (navController.currentDestination?.id == R.id.area_overview_fragment) return
+
         val direction = MapFragmentDirections.navigateToAreaOverviewScreen(areaId = areaId)
 
         onTopoUnselected()
-        findNavController().navigate(direction)
+        navController.navigate(direction)
     }
 
     private fun navigateToSearchScreen() {
+        val navController = findNavController()
+
+        if (navController.currentDestination?.id == R.id.search_fragment) return
+
         onTopoUnselected()
-        findNavController().navigate(MapFragmentDirections.navigateToSearch())
+        navController.navigate(MapFragmentDirections.navigateToSearch())
     }
 
     private fun navigateToFullScreenProblemPhoto(problemId: Int, photoUri: String) {
+        val navController = findNavController()
+
+        if (navController.currentDestination?.id == R.id.full_screen_photo_fragment) return
+
         val direction = MapFragmentDirections.showProblemPhotoFullScreen(
             problemId = problemId,
             photoUri = photoUri
         )
 
-        findNavController().navigate(direction)
+        navController.navigate(direction)
     }
 
     private fun showCircuitFilterBottomSheet(event: MapViewModel.Event.ShowAvailableCircuits) {

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.4.0' apply false
-    id 'com.android.library' version '8.4.0' apply false
+    id 'com.android.application' version '8.4.1' apply false
+    id 'com.android.library' version '8.4.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.23' apply false
     id 'com.google.devtools.ksp' version "1.9.23-1.0.20" apply false


### PR DESCRIPTION
Spamming some buttons that would trigger a navigation could lead to multiple navigation event being processed by the navigation components library, with this kind of stack trace:
```
java.lang.IllegalArgumentException: Navigation action/destination com.boolder.boolder:id/navigate_to_area_overview_screen cannot be found from the current destination Destination(com.boolder.boolder:id/area_overview_fragment) label=Area overview fragment class=com.boolder.boolder.view.areadetails.areaoverview.AreaOverviewFragment
	at androidx.navigation.NavController.navigate(NavController.kt:1691)
	at androidx.navigation.NavController.navigate(NavController.kt:1609)
	at androidx.navigation.NavController.navigate(NavController.kt:2169)
	at com.boolder.boolder.view.map.MapFragment$navigateToAreaOverviewScreen$1.invokeSuspend(MapFragment.kt:458)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:231)
	at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:164)
	at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:466)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:500)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$default(CancellableContinuationImpl.kt:489)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeUndispatched(CancellableContinuationImpl.kt:587)
	at kotlinx.coroutines.android.HandlerContext$scheduleResumeAfterDelay$$inlined$Runnable$1.run(Runnable.kt:15)
	at android.os.Handler.handleCallback(Handler.java:958)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:205)
	at android.os.Looper.loop(Looper.java:294)
	at android.app.ActivityThread.main(ActivityThread.java:8177)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```
and the following behavior:

https://github.com/boolder-org/boolder-android/assets/8343416/3a9d1c98-d9c6-4f55-b44c-6355883c3df1

This behavior is fixed by checking that the current destination is not already the intended one before triggering the navigation

https://github.com/boolder-org/boolder-android/assets/8343416/94575f03-9dc2-4c43-834e-ea06a3f5dd0c
