### PR TITLE
Restore map location when process is recreated

### DIFF
--- a/app/src/main/java/com/boolder/boolder/utils/extension/BundleExtensions.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/extension/BundleExtensions.kt
@@ -1,0 +1,65 @@
+package com.boolder.boolder.utils.extension
+
+import android.os.Bundle
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.CameraState
+import com.mapbox.maps.EdgeInsets
+
+private const val CENTER_LONGITUDE = "CAMERA_CENTER_LONGITUDE"
+private const val CENTER_LATITUDE = "CAMERA_CENTER_LATITUDE"
+private const val PADDING_TOP = "CAMERA_PADDING_TOP"
+private const val PADDING_BOTTOM = "CAMERA_PADDING_BOTTOM"
+private const val PADDING_LEFT = "CAMERA_PADDING_LEFT"
+private const val PADDING_RIGHT = "CAMERA_PADDING_RIGHT"
+private const val ZOOM = "CAMERA_ZOOM"
+private const val BEARING = "CAMERA_BEARING"
+private const val PITCH = "CAMERA_PITCH"
+
+fun Bundle.putCameraState(cameraState: CameraState) {
+    with(cameraState) {
+        putDouble(CENTER_LONGITUDE, center.longitude())
+        putDouble(CENTER_LATITUDE, center.latitude())
+        putDouble(PADDING_TOP, padding.top)
+        putDouble(PADDING_BOTTOM, padding.bottom)
+        putDouble(PADDING_LEFT, padding.left)
+        putDouble(PADDING_RIGHT, padding.right)
+        putDouble(ZOOM, zoom)
+        putDouble(BEARING, bearing)
+        putDouble(PITCH, pitch)
+    }
+}
+
+fun Bundle.containsCameraState(): Boolean =
+    listOf(
+        CENTER_LONGITUDE,
+        CENTER_LATITUDE,
+        PADDING_TOP,
+        PADDING_BOTTOM,
+        PADDING_LEFT,
+        PADDING_RIGHT,
+        ZOOM,
+        BEARING,
+        PITCH
+    ).all { it in keySet() }
+
+fun Bundle.getCameraOptions(): CameraOptions =
+    CameraOptions.Builder()
+        .center(
+            Point.fromLngLat(
+                getDouble(CENTER_LONGITUDE),
+                getDouble(CENTER_LATITUDE)
+            )
+        )
+        .padding(
+            EdgeInsets(
+                getDouble(PADDING_TOP),
+                getDouble(PADDING_BOTTOM),
+                getDouble(PADDING_LEFT),
+                getDouble(PADDING_RIGHT),
+            )
+        )
+        .zoom(getDouble(ZOOM))
+        .bearing(getDouble(BEARING))
+        .pitch(getDouble(PITCH))
+        .build()

--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -29,7 +29,10 @@ import com.boolder.boolder.domain.model.Topo
 import com.boolder.boolder.domain.model.TopoOrigin
 import com.boolder.boolder.utils.LocationProvider
 import com.boolder.boolder.utils.MapboxStyleFactory
+import com.boolder.boolder.utils.extension.containsCameraState
+import com.boolder.boolder.utils.extension.getCameraOptions
 import com.boolder.boolder.utils.extension.launchAndCollectIn
+import com.boolder.boolder.utils.extension.putCameraState
 import com.boolder.boolder.view.areadetails.KEY_AREA_ID
 import com.boolder.boolder.view.areadetails.KEY_CIRCUIT_ID
 import com.boolder.boolder.view.areadetails.KEY_PROBLEM
@@ -315,6 +318,20 @@ class MapFragment : Fragment(), BoolderMapListener {
         binding = null
 
         super.onDestroyView()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+
+        outState.putCameraState(mapView.mapboxMap.cameraState)
+    }
+
+    override fun onViewStateRestored(savedInstanceState: Bundle?) {
+        super.onViewStateRestored(savedInstanceState)
+
+        if (savedInstanceState?.containsCameraState() == true) {
+            mapView.mapboxMap.setCamera(savedInstanceState.getCameraOptions())
+        }
     }
 
     override fun onAttach(context: Context) {


### PR DESCRIPTION
When the app was put in background and the system killed its process to free up some resources, bringing the app in foreground was triggering a process recreation, leading to the loss of the current position on the map.

https://github.com/boolder-org/boolder-android/assets/8343416/b5bb48fc-4489-437a-9c5f-59c70d0fcac2

Saving the state of the camera fixes the issue:

https://github.com/boolder-org/boolder-android/assets/8343416/772afac5-9cee-4691-aebf-8f91352f63a3
