### PR TITLE
Update default map location

### DIFF
--- a/app/src/main/java/com/boolder/boolder/utils/extension/CameraOptionsExtensions.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/extension/CameraOptionsExtensions.kt
@@ -1,5 +1,6 @@
 package com.boolder.boolder.utils.extension
 
+import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 
 fun CameraOptions.coerceZoomAtLeast(minZoom: Double): CameraOptions {
@@ -13,3 +14,9 @@ fun CameraOptions.coerceZoomAtLeast(minZoom: Double): CameraOptions {
         .zoom(zoom.coerceAtLeast(minZoom))
         .build()
 }
+
+fun fontainebleauCameraOptions(): CameraOptions =
+    CameraOptions.Builder()
+        .center(Point.fromLngLat(2.570619713818104, 48.40056240478899))
+        .zoom(9.4)
+        .build()

--- a/app/src/main/java/com/boolder/boolder/utils/extension/CameraStateExtensions.kt
+++ b/app/src/main/java/com/boolder/boolder/utils/extension/CameraStateExtensions.kt
@@ -1,0 +1,11 @@
+package com.boolder.boolder.utils.extension
+
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.CameraState
+
+fun CameraState.toCameraOptions(): CameraOptions =
+    CameraOptions.Builder()
+        .center(center)
+        .padding(padding)
+        .zoom(zoom)
+        .build()

--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -30,9 +30,11 @@ import com.boolder.boolder.domain.model.TopoOrigin
 import com.boolder.boolder.utils.LocationProvider
 import com.boolder.boolder.utils.MapboxStyleFactory
 import com.boolder.boolder.utils.extension.containsCameraState
+import com.boolder.boolder.utils.extension.fontainebleauCameraOptions
 import com.boolder.boolder.utils.extension.getCameraOptions
 import com.boolder.boolder.utils.extension.launchAndCollectIn
 import com.boolder.boolder.utils.extension.putCameraState
+import com.boolder.boolder.utils.extension.toCameraOptions
 import com.boolder.boolder.view.areadetails.KEY_AREA_ID
 import com.boolder.boolder.view.areadetails.KEY_CIRCUIT_ID
 import com.boolder.boolder.view.areadetails.KEY_PROBLEM
@@ -95,16 +97,9 @@ class MapFragment : Fragment(), BoolderMapListener {
     ): View {
         val fragmentMapBinding = FragmentMapBinding.inflate(inflater, container, false)
 
-        val cameraOptions = mapViewModel.cameraState?.let { cameraState ->
-            CameraOptions.Builder()
-                .center(cameraState.center)
-                .padding(cameraState.padding)
-                .zoom(cameraState.zoom)
-                .build()
-        } ?: CameraOptions.Builder()
-            .center(Point.fromLngLat(2.5968216, 48.3925623))
-            .zoom(10.2)
-            .build()
+        val cameraOptions = mapViewModel.cameraState
+            ?.toCameraOptions()
+            ?: fontainebleauCameraOptions()
 
         mapViewModel.cameraState = null
 


### PR DESCRIPTION
New areas located outside of the default camera viewport have been added and they are not immediately visible. An update of this viewport can help to show that they exist.

|Before|After|
|-|-|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/94b2e593-3414-424e-b299-44222a4c72b3" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/155125b0-d799-42f7-ab48-2075e73c2ac6" width=300 />|


