### PR TITLE
Fix edge insets on the map

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/map/extension/MapResourcesExtensions.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/extension/MapResourcesExtensions.kt
@@ -1,0 +1,27 @@
+package com.boolder.boolder.view.map.extension
+
+import android.content.res.Resources
+
+private const val HEIGHT_DP_AREA_BAR = 50
+private const val HEIGHT_DP_FILTERS_BAR = 48
+private const val HEIGHT_DP_TOPO_BOTTOM_SHEET = 354
+private const val HEIGHT_DP_CIRCUIT_START_BUTTON = 48
+private const val HEIGHT_DP_MARGIN_16 = 16
+
+fun Resources.getAreaBarAndFiltersHeight(): Float =
+    displayMetrics.density * (HEIGHT_DP_MARGIN_16 + HEIGHT_DP_AREA_BAR + HEIGHT_DP_MARGIN_16 + HEIGHT_DP_FILTERS_BAR + HEIGHT_DP_MARGIN_16)
+
+fun Resources.getAreaBarHeight(): Float =
+    displayMetrics.density * (HEIGHT_DP_MARGIN_16 + HEIGHT_DP_AREA_BAR)
+
+fun Resources.getTopoBottomSheetHeight(): Float =
+    displayMetrics.density * HEIGHT_DP_TOPO_BOTTOM_SHEET
+
+fun Resources.getTopoBottomSheetHeightWithMargin(): Float =
+    displayMetrics.density * (HEIGHT_DP_TOPO_BOTTOM_SHEET + HEIGHT_DP_MARGIN_16)
+
+fun Resources.getCircuitStartButtonHeight(): Float =
+    displayMetrics.density * (HEIGHT_DP_MARGIN_16 + HEIGHT_DP_CIRCUIT_START_BUTTON + HEIGHT_DP_MARGIN_16)
+
+fun Resources.getDefaultMargin(): Float =
+    displayMetrics.density * HEIGHT_DP_MARGIN_16

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.4.1' apply false
-    id 'com.android.library' version '8.4.1' apply false
+    id 'com.android.application' version '8.4.2' apply false
+    id 'com.android.library' version '8.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.23' apply false
     id 'com.google.devtools.ksp' version "1.9.23-1.0.20" apply false


### PR DESCRIPTION
The map edge insets were incorrect in many situations, not taking in account the real size of the UI overlays nor the status bar's top inset that changes from a device to another

|Before|After|
|-|-|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/5972d0c1-e18f-4c80-b087-efdd27c04799" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/27ea6f67-59d9-420d-9f40-bb3999fb391d" width=300 />|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/4821f9b8-dc43-449a-b5dd-1181fd6df8da" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/ae90f5ec-3a13-4443-a8ed-0718b896adc1" width=300 />|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/d6b67d51-197a-447a-921a-15894b1570b0" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/b3e2dcf6-0cbe-4c00-b395-c63d9918250e" width=300 />|

Resolves #138 