### PR TITLE
Fix crashes from the last release

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -332,7 +332,9 @@ class MapFragment : Fragment(), BoolderMapListener {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
 
-        outState.putCameraState(mapView.mapboxMap.cameraState)
+        if (::mapView.isInitialized) {
+            outState.putCameraState(mapView.mapboxMap.cameraState)
+        }
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
@@ -371,12 +373,16 @@ class MapFragment : Fragment(), BoolderMapListener {
     }
 
     override fun onPoiSelected(poiName: String, googleMapsUrl: String) {
+        val navController = findNavController()
+
+        if (navController.currentDestination?.id == R.id.dialog_poi) return
+
         val direction = MapFragmentDirections.showPoi(
             poiName = poiName,
             googleMapsUrl = googleMapsUrl
         )
 
-        findNavController().navigate(direction)
+        navController.navigate(direction)
     }
 
     override fun onAreaVisited(areaId: Int) {


### PR DESCRIPTION
Two crashes appeared in the last release:

```
Exception kotlin.UninitializedPropertyAccessException: lateinit property mapView has not been initialized
  at com.boolder.boolder.view.map.MapFragment.onSaveInstanceState (MapFragment.kt:328)
  at androidx.fragment.app.Fragment.performSaveInstanceState (Fragment.java:3313)
  at androidx.fragment.app.FragmentStateManager.saveState (FragmentStateManager.java:702)
  at androidx.fragment.app.FragmentStore.saveActiveFragments (FragmentStore.java:217)
  at androidx.fragment.app.FragmentManager.saveAllStateInternal (FragmentManager.java:2435)
  at androidx.fragment.app.FragmentStateManager.saveState (FragmentStateManager.java:715)
  at androidx.fragment.app.FragmentStore.saveActiveFragments (FragmentStore.java:217)
  at androidx.fragment.app.FragmentManager.saveAllStateInternal (FragmentManager.java:2435)
  at androidx.fragment.app.FragmentManager.lambda$attachController$4$androidx-fragment-app-FragmentManager (FragmentManager.java:2715)
  at androidx.fragment.app.FragmentManager$$ExternalSyntheticLambda4.saveState (D8$$SyntheticClass)
  ...
```

```
Exception java.lang.IllegalArgumentException:
  at androidx.navigation.NavController.navigate (NavController.kt:1691)
  at androidx.navigation.NavController.navigate (NavController.kt:1609)
  at androidx.navigation.NavController.navigate (NavController.kt:2169)
  at com.boolder.boolder.view.map.MapFragment.onPoiSelected (MapFragment.kt:372)
  at com.boolder.boolder.view.map.BoolderMap.queryPoisRenderedFeatures$lambda$10 (BoolderMap.kt:255)
  at com.boolder.boolder.view.map.BoolderMap.$r8$lambda$1Poc1sL08jObBlYG8J22YIohRFY
  at com.boolder.boolder.view.map.BoolderMap$$ExternalSyntheticLambda1.run (D8$$SyntheticClass)
```