### PR TITLE
Fix topo footer with no steepness but a sit start

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/detail/composable/TopoFooter.kt
+++ b/app/src/main/java/com/boolder/boolder/view/detail/composable/TopoFooter.kt
@@ -132,24 +132,20 @@ private fun TopoProblemSteepness(
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurface
             )
-
-            val steepnessText = stringResource(id = steepness.textRes)
-            val text = if (isSitStart) {
-                listOf(steepnessText, stringResource(id = R.string.sit_start))
-                    .joinToString(separator = " • ")
-            } else {
-                steepnessText
-            }
-
-            Text(
-                modifier = Modifier.weight(1f),
-                text = text,
-                color = MaterialTheme.colorScheme.onSurface,
-                fontSize = 18.sp
-            )
-        } else {
-            Spacer(modifier = Modifier.weight(1f))
         }
+
+        val text = listOfNotNull(
+            steepness?.textRes?.let { stringResource(id = it) },
+            if (isSitStart) stringResource(id = R.string.sit_start) else null
+        ).joinToString(separator = " • ")
+
+        Text(
+            text = text,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontSize = 18.sp
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
 
         tickStatus?.let {
             val (iconRes, tintColor) = when (it) {
@@ -301,6 +297,33 @@ private class TopoFooterPreviewParameterProvider : PreviewParameterProvider<Prob
         dummyProblem(tickStatus = null),
         dummyProblem(tickStatus = TickStatus.PROJECT),
         dummyProblem(tickStatus = TickStatus.SUCCEEDED),
+        dummyProblem(
+            sitStart = false,
+            tickStatus = null
+        ),
+        dummyProblem(
+            sitStart = false,
+            tickStatus = TickStatus.PROJECT
+        ),
+        dummyProblem(
+            sitStart = false,
+            tickStatus = TickStatus.SUCCEEDED
+        ),
+        dummyProblem(
+            steepness = "",
+            sitStart = true,
+            tickStatus = null
+        ),
+        dummyProblem(
+            steepness = "",
+            sitStart = true,
+            tickStatus = TickStatus.PROJECT
+        ),
+        dummyProblem(
+            steepness = "",
+            sitStart = true,
+            tickStatus = TickStatus.SUCCEEDED
+        ),
         dummyProblem(
             steepness = "",
             sitStart = false,


### PR DESCRIPTION
The "sit start" mention was missing in the topo when the problem had a sit start but no steepness to mention

|Before|Reference (iOS)|After|
|-|-|-|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/64ee36d4-535a-4770-88dc-6a0f31a1529c" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/e03353ef-52bd-4ba5-a9e6-3498f87aeaba" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/61a0b17d-6bae-4192-a1a9-9d12192882f0" width=300 />|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/37c7880b-2f91-4d9d-b478-27ab9ac9aca6" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/74a1ce19-e66c-4f4f-84b1-8b8559029ce3" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/67ee4a81-65d5-4d6d-b37f-7e638dddb27b" width=300 />|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/068db7a8-d967-44ba-9c99-8e67a60f8d39" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/f442bb6b-42da-49f5-9448-62632b1fd21b" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/ef7d8c95-7966-4466-8165-7d274857ce8e" width=300 />|
|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/511f9b88-2ba0-410e-99a6-8fa01e09b679" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/4464eab1-1050-4ffe-8386-9cacf9b5deb8" width=300 />|<img src="https://github.com/boolder-org/boolder-android/assets/8343416/68a7d2d4-2bc6-493b-856d-83f5e60ad991" width=300 />|
