### PR TITLE
Add area download FAB

### DIFF
--- a/app/src/main/java/com/boolder/boolder/data/database/dao/AreaDao.kt
+++ b/app/src/main/java/com/boolder/boolder/data/database/dao/AreaDao.kt
@@ -73,4 +73,18 @@ interface AreaDao {
         ORDER BY pois.id ASC, poi_routes.distance_in_minutes ASC
     """)
     suspend fun getTrainStationPoiWithBikeRoutes(): List<TrainStationPoiWithBikeRoutes>
+
+    @Query("""
+        SELECT id FROM areas 
+        WHERE north_east_lat > :latSouth AND :latNorth > south_west_lat
+            AND north_east_lon > :lonWest AND :lonEast > south_west_lon
+        ORDER BY priority ASC, name ASC
+        LIMIT 5
+    """)
+    suspend fun getIntersectingAreaIds(
+        latNorth: Float,
+        latSouth: Float,
+        lonEast: Float,
+        lonWest: Float
+    ): List<Int>
 }

--- a/app/src/main/java/com/boolder/boolder/data/database/repository/AreaRepository.kt
+++ b/app/src/main/java/com/boolder/boolder/data/database/repository/AreaRepository.kt
@@ -59,4 +59,24 @@ class AreaRepository(
                 )
             }
         )
+
+    suspend fun getNearbyAreaIds(area: Area): List<Int> =
+        areaDao.getIntersectingAreaIds(
+            latNorth = area.northEastLat + NEARBY_THRESHOLD_IN_LATITUDE_DEGREES,
+            latSouth = area.southWestLat - NEARBY_THRESHOLD_IN_LATITUDE_DEGREES,
+            lonWest = area.southWestLon - NEARBY_THRESHOLD_IN_LONGITUDE_DEGREES,
+            lonEast = area.northEastLon + NEARBY_THRESHOLD_IN_LONGITUDE_DEGREES
+        ).filter { it != area.id }
+
+    companion object {
+        private const val NEARBY_THRESHOLD_KM = .5
+
+        private const val EARTH_CIRCUMFERENCE_KM = 40_075.017
+        private const val LONGITUDE_DEGREE_IN_KM = EARTH_CIRCUMFERENCE_KM / 360.0
+        private const val NEARBY_THRESHOLD_IN_LONGITUDE_DEGREES = (NEARBY_THRESHOLD_KM / LONGITUDE_DEGREE_IN_KM).toFloat()
+
+        private const val EARTH_POLAR_CIRCUMFERENCE_KM = 40_007.863
+        private const val LATITUDE_DEGREE_IN_KM = EARTH_POLAR_CIRCUMFERENCE_KM / 360.0
+        private const val NEARBY_THRESHOLD_IN_LATITUDE_DEGREES = (NEARBY_THRESHOLD_KM / LATITUDE_DEGREE_IN_KM).toFloat()
+    }
 }

--- a/app/src/main/java/com/boolder/boolder/offline/Constants.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/Constants.kt
@@ -1,13 +1,5 @@
 package com.boolder.boolder.offline
 
-import androidx.work.WorkInfo
-
 // Progress keys
 const val WORK_DATA_PROGRESS = "progress"
 const val WORK_DATA_PROGRESS_DETAIL = "progress_detail"
-
-val DOWNLOAD_TERMINATED_STATUSES = arrayOf(
-    WorkInfo.State.SUCCEEDED,
-    WorkInfo.State.FAILED,
-    WorkInfo.State.CANCELLED
-)

--- a/app/src/main/java/com/boolder/boolder/offline/OfflineAreaDownloader.kt
+++ b/app/src/main/java/com/boolder/boolder/offline/OfflineAreaDownloader.kt
@@ -3,13 +3,11 @@ package com.boolder.boolder.offline
 interface OfflineAreaDownloader {
     fun onDownloadArea(areaId: Int)
     fun onCancelAreaDownload(areaId: Int)
-    fun onAreaDownloadTerminated(areaId: Int)
     fun onDeleteAreaPhotos(areaId: Int)
 }
 
 fun dummyOfflineAreaDownloader() = object : OfflineAreaDownloader {
     override fun onDownloadArea(areaId: Int) {}
     override fun onCancelAreaDownload(areaId: Int) {}
-    override fun onAreaDownloadTerminated(areaId: Int) {}
     override fun onDeleteAreaPhotos(areaId: Int) {}
 }

--- a/app/src/main/java/com/boolder/boolder/view/ViewModules.kt
+++ b/app/src/main/java/com/boolder/boolder/view/ViewModules.kt
@@ -14,6 +14,7 @@ import com.boolder.boolder.view.discover.levels.beginner.BeginnerLevelsViewModel
 import com.boolder.boolder.view.discover.trainandbike.TrainAndBikeViewModel
 import com.boolder.boolder.view.fullscreenphoto.FullScreenPhotoViewModel
 import com.boolder.boolder.view.map.MapViewModel
+import com.boolder.boolder.view.map.areadownload.AreaDownloadViewModel
 import com.boolder.boolder.view.map.filter.grade.GradesFilterViewModel
 import com.boolder.boolder.view.offlinephotos.OfflinePhotosViewModel
 import com.boolder.boolder.view.offlinephotos.OfflinePhotosViewModelImpl
@@ -50,4 +51,6 @@ val viewModelModule = module {
     viewModelOf(::TickListViewModel)
 
     viewModelOf(::FullScreenPhotoViewModel)
+
+    viewModelOf(::AreaDownloadViewModel)
 }

--- a/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/areadetails/areaoverview/AreaOverviewViewModel.kt
@@ -37,42 +37,25 @@ class AreaOverviewViewModel(
             val circuits = circuitRepository.getAvailableCircuits(areaId)
             val accessesFromPoi = areaRepository.getAccessesFromPoiByAreaId(areaId)
 
-            _screenState.value = ScreenState.Content(
-                area = area,
-                circuits = circuits,
-                accessesFromPoi = accessesFromPoi,
-                offlineAreaItemStatus = boolderOfflineRepository.getStatusForAreaId(areaId)
-            )
+            boolderOfflineRepository.getStatusForAreaIdFlow(areaId)
+                .collect { offlineAreaItemStatus ->
+                    _screenState.value = ScreenState.Content(
+                        area = area,
+                        circuits = circuits,
+                        accessesFromPoi = accessesFromPoi,
+                        offlineAreaItemStatus = offlineAreaItemStatus
+                    )
+                }
         }
     }
 
     override fun onDownloadArea(areaId: Int) {
-        val currentState = _screenState.value as? ScreenState.Content ?: return
-
-        _screenState.update {
-            currentState.copy(offlineAreaItemStatus = OfflineAreaItemStatus.Downloading(areaId))
-        }
-
         boolderOfflineRepository.downloadArea(areaId)
     }
 
     override fun onCancelAreaDownload(areaId: Int) {
-        val currentState = _screenState.value as? ScreenState.Content ?: return
-
-        boolderOfflineRepository.cancelAreaDownload(areaId)
         boolderOfflineRepository.deleteArea(areaId)
-
-        _screenState.update {
-            currentState.copy(offlineAreaItemStatus = OfflineAreaItemStatus.NotDownloaded)
-        }
-    }
-
-    override fun onAreaDownloadTerminated(areaId: Int) {
-        val currentState = _screenState.value as? ScreenState.Content ?: return
-
-        val newStatus = boolderOfflineRepository.getStatusForAreaId(areaId)
-
-        _screenState.update { currentState.copy(offlineAreaItemStatus = newStatus) }
+        boolderOfflineRepository.cancelAreaDownload(areaId)
     }
 
     override fun onDeleteAreaPhotos(areaId: Int) {

--- a/app/src/main/java/com/boolder/boolder/view/compose/Shimmer.kt
+++ b/app/src/main/java/com/boolder/boolder/view/compose/Shimmer.kt
@@ -1,0 +1,53 @@
+package com.boolder.boolder.view.compose
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+fun Modifier.shimmerLoading(
+    durationMillis: Int = 1000,
+    widthOfShadowBrush: Int = 500,
+    angleOfYAxis: Float = 270f
+): Modifier = composed {
+    val baseColor = if (isSystemInDarkTheme()) Color.White else Color.Black
+    val shimmerColors = listOf(
+        baseColor.copy(alpha = 0.3f),
+        baseColor.copy(alpha = 0.1f),
+        baseColor.copy(alpha = 0.0f),
+        baseColor.copy(alpha = 0.1f),
+        baseColor.copy(alpha = 0.3f),
+    )
+
+    val transition = rememberInfiniteTransition(label = "")
+
+    val translateAnimation = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = (durationMillis + widthOfShadowBrush).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = durationMillis,
+                easing = LinearEasing,
+            ),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "Shimmer loading animation",
+    )
+
+    background(
+        brush = Brush.linearGradient(
+            colors = shimmerColors,
+            start = Offset(x = translateAnimation.value - widthOfShadowBrush, y = 0.0f),
+            end = Offset(x = translateAnimation.value, y = angleOfYAxis),
+        )
+    )
+}

--- a/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
@@ -23,6 +23,7 @@ import com.boolder.boolder.utils.extension.coerceZoomAtLeast
 import com.boolder.boolder.view.map.animator.animationEndListener
 import com.boolder.boolder.view.map.extension.getAreaBarAndFiltersHeight
 import com.boolder.boolder.view.map.extension.getAreaBarHeight
+import com.boolder.boolder.view.map.extension.getCircuitHorizontalMargin
 import com.boolder.boolder.view.map.extension.getCircuitStartButtonHeight
 import com.boolder.boolder.view.map.extension.getDefaultMargin
 import com.boolder.boolder.view.map.extension.getTopoBottomSheetHeight
@@ -421,12 +422,12 @@ class BoolderMap(
     private fun zoomToCircuitBounds(circuitCoordinates: List<Point>) {
         val topInset = insets.top + resources.getAreaBarAndFiltersHeight().toDouble()
         val bottomInset = resources.getCircuitStartButtonHeight().toDouble()
-        val defaultInset = resources.getDefaultMargin().toDouble()
+        val lateralInset = resources.getCircuitHorizontalMargin().toDouble()
 
         val cameraOptions = mapboxMap.cameraForCoordinates(
             coordinates = circuitCoordinates,
             camera = CameraOptions.Builder().build(),
-            coordinatesPadding = EdgeInsets(topInset, defaultInset, bottomInset, defaultInset),
+            coordinatesPadding = EdgeInsets(topInset, lateralInset, bottomInset, lateralInset),
             maxZoom = null,
             offset = null
         ).coerceZoomAtLeast(15.0)

--- a/app/src/main/java/com/boolder/boolder/view/map/areadownload/AreaDownloadBottomSheetDialog.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/areadownload/AreaDownloadBottomSheetDialog.kt
@@ -1,4 +1,4 @@
-package com.boolder.boolder.view.offlinephotos
+package com.boolder.boolder.view.map.areadownload
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -6,14 +6,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boolder.boolder.view.compose.BoolderTheme
+import com.boolder.boolder.view.custom.EdgeToEdgeBottomSheetDialogFragment
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class OfflinePhotosFragment : Fragment() {
+class AreaDownloadBottomSheetDialog : EdgeToEdgeBottomSheetDialogFragment() {
 
-    private val viewModel by viewModel<OfflinePhotosViewModel>()
+    private val viewModel by viewModel<AreaDownloadViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -25,7 +25,7 @@ class OfflinePhotosFragment : Fragment() {
                 BoolderTheme {
                     val screenState by viewModel.screenState.collectAsStateWithLifecycle()
 
-                    OfflinePhotosScreen(
+                    AreaDownloadLayout(
                         screenState = screenState,
                         offlineAreaDownloader = viewModel
                     )

--- a/app/src/main/java/com/boolder/boolder/view/map/areadownload/AreaDownloadLayout.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/areadownload/AreaDownloadLayout.kt
@@ -1,0 +1,365 @@
+package com.boolder.boolder.view.map.areadownload
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.boolder.boolder.R
+import com.boolder.boolder.offline.OfflineAreaDownloader
+import com.boolder.boolder.offline.dummyOfflineAreaDownloader
+import com.boolder.boolder.utils.previewgenerator.dummyArea
+import com.boolder.boolder.utils.previewgenerator.dummyOfflineAreaItem
+import com.boolder.boolder.view.compose.BoolderOrange
+import com.boolder.boolder.view.compose.BoolderTheme
+import com.boolder.boolder.view.compose.shimmerLoading
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
+
+@Composable
+internal fun AreaDownloadLayout(
+    screenState: AreaDownloadViewModel.ScreenState,
+    offlineAreaDownloader: OfflineAreaDownloader,
+    modifier: Modifier = Modifier
+) {
+    val displayNearbyItems = when {
+        screenState.loadingNearbyItemsCount != null -> screenState.loadingNearbyItemsCount > 0
+        screenState.content != null -> screenState.content.nearbyAreaItems.isNotEmpty()
+        else -> false
+    }
+
+    AreaDownloadScaffold(
+        modifier = modifier,
+        displayNearbyItems = displayNearbyItems,
+        currentArea = {
+            screenState.loadingNearbyItemsCount?.let { LoadingAreaItem() }
+
+            screenState.content?.let {
+                AreaItem(
+                    offlineAreaItem = it.offlineAreaItem,
+                    offlineAreaDownloader = offlineAreaDownloader
+                )
+            }
+        },
+        nearbyAreas = {
+            screenState.loadingNearbyItemsCount?.let {
+                repeat(it) { index ->
+                    if (index > 0) HorizontalDivider(color = MaterialTheme.colorScheme.outline)
+
+                    LoadingAreaItem()
+                }
+            }
+
+            screenState.content?.let {
+                it.nearbyAreaItems.forEachIndexed { index, item ->
+                    if (index > 0) HorizontalDivider(color = MaterialTheme.colorScheme.outline)
+
+                    AreaItem(
+                        offlineAreaItem = item,
+                        offlineAreaDownloader = offlineAreaDownloader
+                    )
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun AreaDownloadScaffold(
+    displayNearbyItems: Boolean,
+    currentArea: @Composable () -> Unit,
+    nearbyAreas: @Composable () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+            .background(color = MaterialTheme.colorScheme.surface)
+            .navigationBarsPadding()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = spacedBy(16.dp)
+    ) {
+        Text(
+            text = stringResource(id = R.string.area_download_sheet_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        SectionColumn { currentArea() }
+
+        if (displayNearbyItems) {
+            Text(
+                modifier = Modifier
+                    .align(Alignment.Start)
+                    .padding(top = 8.dp),
+                text = stringResource(id = R.string.area_download_sheet_nearby_areas),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            SectionColumn { nearbyAreas() }
+        }
+    }
+}
+
+@Composable
+private fun SectionColumn(content: @Composable () -> Unit) {
+    val shape = RoundedCornerShape(16.dp)
+
+    Column(
+        modifier = Modifier
+            .clip(shape = shape)
+            .border(width = 1.dp, color = MaterialTheme.colorScheme.outline, shape = shape)
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun LoadingAreaItem() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .height(16.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .shimmerLoading()
+        )
+
+        Box(
+            modifier = Modifier
+                .size(24.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .shimmerLoading()
+        )
+    }
+}
+
+@Composable
+private fun AreaItem(
+    offlineAreaItem: OfflineAreaItem,
+    offlineAreaDownloader: OfflineAreaDownloader
+) {
+    var showCancelDialog by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .clickable {
+                when (offlineAreaItem.status) {
+                    is OfflineAreaItemStatus.NotDownloaded -> offlineAreaDownloader.onDownloadArea(
+                        offlineAreaItem.area.id
+                    )
+
+                    is OfflineAreaItemStatus.Downloading -> showCancelDialog = true
+                    is OfflineAreaItemStatus.Downloaded -> showDeleteDialog = true
+                }
+            }
+            .padding(16.dp)
+    ) {
+        Text(
+            modifier = Modifier.weight(1f),
+            text = offlineAreaItem.area.name,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        AreaItemIcon(item = offlineAreaItem)
+    }
+
+    if (showCancelDialog) {
+        AlertDialog(
+            icon = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_error_outline),
+                    contentDescription = null,
+                    tint = Color.BoolderOrange
+                )
+            },
+            title = { Text(text = stringResource(id = R.string.photos_download_cancellation_dialog_title)) },
+            text = { Text(text = stringResource(id = R.string.photos_download_cancellation_dialog_text)) },
+            onDismissRequest = { showCancelDialog = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        offlineAreaDownloader.onCancelAreaDownload(offlineAreaItem.area.id)
+                        showCancelDialog = false
+                    },
+                    content = { Text(text = stringResource(id = R.string.photos_download_cancellation_dialog_confirm_button)) }
+                )
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showCancelDialog = false },
+                    content =  { Text(text = stringResource(id = R.string.photos_download_cancellation_dialog_cancel_button)) }
+                )
+            }
+        )
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            icon = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_error_outline),
+                    contentDescription = null,
+                    tint = Color.BoolderOrange
+                )
+            },
+            title = { Text(text = stringResource(id = R.string.photos_download_deletion_dialog_title)) },
+            text = { Text(text = stringResource(id = R.string.photos_download_deletion_dialog_text)) },
+            onDismissRequest = { showDeleteDialog = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteDialog = false
+                        offlineAreaDownloader.onDeleteAreaPhotos(offlineAreaItem.area.id)
+                    },
+                    content = { Text(text = stringResource(id = R.string.photos_download_deletion_dialog_confirm_button)) }
+                )
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDeleteDialog = false },
+                    content = { Text(text = stringResource(id = R.string.photos_download_deletion_dialog_cancel_button)) }
+                )
+            }
+        )
+    }
+}
+
+@Composable
+private fun AreaItemIcon(item: OfflineAreaItem) {
+    when (item.status) {
+        is OfflineAreaItemStatus.NotDownloaded -> Icon(
+            painter = painterResource(id = R.drawable.ic_download_for_offline),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface
+        )
+        is OfflineAreaItemStatus.Downloading -> {
+            val infiniteTransition = rememberInfiniteTransition("rotationAngle")
+            val rotationAngle by infiniteTransition.animateFloat(
+                label = "rotationAngle",
+                initialValue = 0f,
+                targetValue = 360f,
+                animationSpec = infiniteRepeatable(
+                    tween(
+                        durationMillis = 1_500,
+                        easing = LinearEasing
+                    )
+                )
+            )
+
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .size(24.dp)
+                    .graphicsLayer { rotationZ = rotationAngle },
+                progress = { item.status.progress.coerceAtLeast(.05f) }
+            )
+        }
+        is OfflineAreaItemStatus.Downloaded -> Icon(
+            painter = painterResource(id = R.drawable.ic_download_done),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun AreaDownloadLayoutPreview(
+    @PreviewParameter(AreaDownloadLayoutPreviewParameterProvider::class)
+    screenState: AreaDownloadViewModel.ScreenState
+) {
+    BoolderTheme {
+        AreaDownloadLayout(
+            screenState = screenState,
+            offlineAreaDownloader = dummyOfflineAreaDownloader()
+        )
+    }
+}
+
+private class AreaDownloadLayoutPreviewParameterProvider : PreviewParameterProvider<AreaDownloadViewModel.ScreenState> {
+    private val loadingState = AreaDownloadViewModel.ScreenState(
+        loadingNearbyItemsCount = 3,
+        content = null
+    )
+
+    private val contents = listOf(
+        OfflineAreaItemStatus.NotDownloaded,
+        OfflineAreaItemStatus.Downloading(progress = .6f, progressDetail = "6/10"),
+        OfflineAreaItemStatus.Downloaded(folderSize = "33 MB"),
+    ).map {
+        AreaDownloadViewModel.ScreenState(
+            loadingNearbyItemsCount = null,
+            content = AreaDownloadViewModel.Content(
+                offlineAreaItem = dummyOfflineAreaItem(
+                    area = dummyArea(name = "Franchard Isatis"),
+                    status = it
+                ),
+                nearbyAreaItems = listOf(
+                    dummyOfflineAreaItem(
+                        area = dummyArea(name = "Franchard Sablons"),
+                        status = OfflineAreaItemStatus.NotDownloaded
+                    ),
+                    dummyOfflineAreaItem(
+                        area = dummyArea(name = "Franchard Cuisinière"),
+                        status = OfflineAreaItemStatus.Downloading(progress = .3f, progressDetail = "3/10")
+                    ),
+                    dummyOfflineAreaItem(
+                        area = dummyArea(name = "Franchard Hautes Plaines"),
+                        status = OfflineAreaItemStatus.Downloaded(folderSize = "40MB")
+                    )
+                )
+            )
+        )
+    }
+
+    override val values = listOf(loadingState)
+        .plus(contents)
+        .asSequence()
+}

--- a/app/src/main/java/com/boolder/boolder/view/map/areadownload/AreaDownloadViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/areadownload/AreaDownloadViewModel.kt
@@ -1,0 +1,124 @@
+package com.boolder.boolder.view.map.areadownload
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.boolder.boolder.data.database.repository.AreaRepository
+import com.boolder.boolder.offline.BoolderOfflineRepository
+import com.boolder.boolder.offline.OfflineAreaDownloader
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class AreaDownloadViewModel(
+    savedStateHandle: SavedStateHandle,
+    private val areaRepository: AreaRepository,
+    private val boolderOfflineRepository: BoolderOfflineRepository
+) : ViewModel(), OfflineAreaDownloader {
+
+    private val areaId = requireNotNull(savedStateHandle.get<Int>("area_id"))
+    private val nearbyAreaIds = requireNotNull(savedStateHandle.get<IntArray>("nearby_area_ids"))
+
+    private val _screenState = MutableStateFlow(
+        ScreenState(loadingNearbyItemsCount = nearbyAreaIds.size)
+    )
+    val screenState = _screenState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val area = areaRepository.getAreaById(areaId) ?: return@launch
+
+            val nearbyAreas = nearbyAreaIds
+                .toList()
+                .mapNotNull { areaRepository.getAreaById(it) ?: return@mapNotNull null }
+
+            val nearbyAreaItemsFlow = if (nearbyAreas.isEmpty()) {
+                flowOf(emptyList())
+            } else {
+                combine(
+                    flows = nearbyAreas.map { nearbyArea ->
+                        boolderOfflineRepository.getStatusForAreaIdFlow(nearbyArea.id)
+                    },
+                    transform = { nearbyAreaStatuses ->
+                        nearbyAreaStatuses.mapIndexed { index, status ->
+                            OfflineAreaItem(
+                                area = nearbyAreas[index],
+                                status = status
+                            )
+                        }
+                    }
+                )
+            }
+
+            combine(
+                flow = boolderOfflineRepository.getStatusForAreaIdFlow(areaId),
+                flow2 = nearbyAreaItemsFlow,
+                transform = { areaStatus, nearbyAreaItems -> areaStatus to nearbyAreaItems }
+            ).collect { (offlineAreaItemStatus, nearbyAreaItems) ->
+                _screenState.update {
+                    ScreenState(
+                        loadingNearbyItemsCount = null,
+                        content = Content(
+                            offlineAreaItem = OfflineAreaItem(
+                                area = area,
+                                status = offlineAreaItemStatus
+                            ),
+                            nearbyAreaItems = nearbyAreaItems
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    // region OfflineAreaDownloader
+
+    override fun onDownloadArea(areaId: Int) {
+        val areaItem = checkArea(areaId)
+            ?.takeIf { it.status is OfflineAreaItemStatus.NotDownloaded }
+            ?: return
+
+        boolderOfflineRepository.downloadArea(areaItem.area.id)
+    }
+
+    override fun onCancelAreaDownload(areaId: Int) {
+        val areaItem = checkArea(areaId)
+            ?.takeIf { it.status is OfflineAreaItemStatus.Downloading }
+            ?: return
+
+        boolderOfflineRepository.cancelAreaDownload(areaItem.area.id)
+        boolderOfflineRepository.deleteArea(areaItem.area.id)
+    }
+
+    override fun onDeleteAreaPhotos(areaId: Int) {
+        val areaItem = checkArea(areaId)
+            ?.takeIf { it.status is OfflineAreaItemStatus.Downloaded }
+            ?: return
+
+        boolderOfflineRepository.deleteArea(areaItem.area.id)
+    }
+
+    private fun checkArea(areaId: Int): OfflineAreaItem? {
+        val currentScreenState = screenState.value.content ?: return null
+
+        return (currentScreenState.nearbyAreaItems + currentScreenState.offlineAreaItem)
+            .find { it.area.id == areaId }
+    }
+
+    // endregion OfflineAreaDownloader
+
+    data class ScreenState(
+        val loadingNearbyItemsCount: Int?,
+        val content: Content? = null
+    )
+
+    data class Content(
+        val offlineAreaItem: OfflineAreaItem,
+        val nearbyAreaItems: List<OfflineAreaItem> = emptyList()
+    )
+}

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/MapControlsOverlay.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/MapControlsOverlay.kt
@@ -1,16 +1,28 @@
 package com.boolder.boolder.view.map.composable
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -40,6 +52,8 @@ fun MapControlsOverlay(
     onAreaInfoClicked: () -> Unit,
     onSearchBarClicked: () -> Unit,
     onCircuitStartClicked: () -> Unit,
+    onDownloadAreaClicked: () -> Unit,
+    onFindMyPositionClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -61,24 +75,92 @@ fun MapControlsOverlay(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        if (circuitState?.showCircuitStartButton == true) {
-            Button(
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(bottom = 16.dp),
-                colors = ButtonDefaults.elevatedButtonColors(),
-                onClick = onCircuitStartClicked
-            ) {
-                Text(
-                    text = stringResource(id = R.string.circuit_start),
-                    style = MaterialTheme.typography.labelLarge,
-                    color = when (val circuitColor = circuitState.color) {
-                        CircuitColor.WHITE,
-                        CircuitColor.BLACK -> MaterialTheme.colorScheme.onSurface
-                        else -> circuitColor.composeColor()
-                    }
-                )
+        Box(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            MapFloatingActionButtons(
+                modifier = Modifier.align(Alignment.BottomEnd),
+                offlineAreaItem = offlineAreaItem,
+                onDownloadAreaClicked = onDownloadAreaClicked,
+                onFindMyPositionClicked = onFindMyPositionClicked
+            )
+
+            if (circuitState?.showCircuitStartButton == true) {
+                Button(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 16.dp),
+                    colors = ButtonDefaults.elevatedButtonColors(),
+                    onClick = onCircuitStartClicked
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.circuit_start),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = when (val circuitColor = circuitState.color) {
+                            CircuitColor.WHITE,
+                            CircuitColor.BLACK -> MaterialTheme.colorScheme.onSurface
+
+                            else -> circuitColor.composeColor()
+                        }
+                    )
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun MapFloatingActionButtons(
+    offlineAreaItem: OfflineAreaItem?,
+    onDownloadAreaClicked: () -> Unit,
+    onFindMyPositionClicked: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = spacedBy(16.dp)
+    ) {
+        AnimatedVisibility(
+            visible = offlineAreaItem != null,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            SmallFloatingActionButton(
+                containerColor = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 0.dp),
+                onClick = onDownloadAreaClicked
+            ) {
+                when (offlineAreaItem?.status) {
+                    is OfflineAreaItemStatus.Downloading -> CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp)
+                    )
+
+                    is OfflineAreaItemStatus.Downloaded -> Icon(
+                        painter = painterResource(id = R.drawable.ic_download_done),
+                        contentDescription = stringResource(id = R.string.cd_downloaded_area),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+
+                    else -> Icon(
+                        painter = painterResource(id = R.drawable.ic_download_for_offline),
+                        contentDescription = stringResource(id = R.string.cd_download_area)
+                    )
+                }
+            }
+        }
+
+        SmallFloatingActionButton(
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 0.dp),
+            onClick = onFindMyPositionClicked
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_fab_near_me),
+                contentDescription = stringResource(id = R.string.cd_find_my_position)
+            )
         }
     }
 }
@@ -109,7 +191,9 @@ private fun MapControlsOverlayPreview() {
             onHideAreaName = {},
             onAreaInfoClicked = {},
             onSearchBarClicked = {},
-            onCircuitStartClicked = {}
+            onCircuitStartClicked = {},
+            onDownloadAreaClicked = {},
+            onFindMyPositionClicked = {}
         )
     }
 }

--- a/app/src/main/java/com/boolder/boolder/view/map/extension/MapResourcesExtensions.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/extension/MapResourcesExtensions.kt
@@ -23,5 +23,8 @@ fun Resources.getTopoBottomSheetHeightWithMargin(): Float =
 fun Resources.getCircuitStartButtonHeight(): Float =
     displayMetrics.density * (HEIGHT_DP_MARGIN_16 + HEIGHT_DP_CIRCUIT_START_BUTTON + HEIGHT_DP_MARGIN_16)
 
+fun Resources.getCircuitHorizontalMargin(): Float =
+    displayMetrics.density * HEIGHT_DP_MARGIN_16 * 4
+
 fun Resources.getDefaultMargin(): Float =
     displayMetrics.density * HEIGHT_DP_MARGIN_16

--- a/app/src/main/java/com/boolder/boolder/view/offlinephotos/OfflinePhotosScreen.kt
+++ b/app/src/main/java/com/boolder/boolder/view/offlinephotos/OfflinePhotosScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.boolder.boolder.domain.model.Area
+import com.boolder.boolder.offline.OfflineAreaDownloader
+import com.boolder.boolder.offline.dummyOfflineAreaDownloader
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.offlinephotos.composable.OfflinePhotosAreaItem
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
@@ -29,10 +31,7 @@ import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
 @Composable
 fun OfflinePhotosScreen(
     screenState: OfflinePhotosViewModel.ScreenState,
-    onDownloadAreaClicked: (Int) -> Unit,
-    onDownloadTerminated: (Int) -> Unit,
-    onCancelDownload: (Int) -> Unit,
-    onDeleteAreaClicked: (Int) -> Unit,
+    offlineAreaDownloader: OfflineAreaDownloader,
     modifier: Modifier = Modifier
 ) {
     val internalModifier = modifier
@@ -45,10 +44,7 @@ fun OfflinePhotosScreen(
         OfflinePhotosScreenContent(
             modifier = internalModifier,
             screenState = screenState,
-            onDownloadAreaClicked = onDownloadAreaClicked,
-            onDownloadTerminated = onDownloadTerminated,
-            onCancelDownload = onCancelDownload,
-            onDeleteAreaClicked = onDeleteAreaClicked
+            offlineAreaDownloader = offlineAreaDownloader
         )
     }
 }
@@ -68,10 +64,7 @@ private fun OfflinePhotosScreenLoading(
 @Composable
 private fun OfflinePhotosScreenContent(
     screenState: OfflinePhotosViewModel.ScreenState,
-    onDownloadAreaClicked: (Int) -> Unit,
-    onDownloadTerminated: (Int) -> Unit,
-    onCancelDownload: (Int) -> Unit,
-    onDeleteAreaClicked: (Int) -> Unit,
+    offlineAreaDownloader: OfflineAreaDownloader,
     modifier: Modifier = Modifier
 ) {
     val systemBarsInsets = WindowInsets.systemBars.asPaddingValues()
@@ -93,10 +86,9 @@ private fun OfflinePhotosScreenContent(
             OfflinePhotosAreaItem(
                 areaName = it.area.name,
                 status = it.status,
-                onDownloadClicked = { onDownloadAreaClicked(it.area.id) },
-                onDownloadTerminated = { onDownloadTerminated(it.area.id) },
-                onCancelDownload = { onCancelDownload(it.area.id) },
-                onDeleteClicked = { onDeleteAreaClicked(it.area.id) }
+                onDownloadClicked = { offlineAreaDownloader.onDownloadArea(it.area.id) },
+                onCancelDownload = { offlineAreaDownloader.onCancelAreaDownload(it.area.id) },
+                onDeleteClicked = { offlineAreaDownloader.onDeleteAreaPhotos(it.area.id) }
             )
         }
     }
@@ -111,10 +103,7 @@ private fun OfflinePhotosScreenPreview(
     BoolderTheme {
         OfflinePhotosScreen(
             screenState = screenState,
-            onDownloadAreaClicked = {},
-            onDownloadTerminated = {},
-            onCancelDownload = {},
-            onDeleteAreaClicked = {}
+            offlineAreaDownloader = dummyOfflineAreaDownloader()
         )
     }
 }
@@ -145,7 +134,7 @@ private class OfflinePhotosScreenPreviewParameterProvider :
                 area = area,
                 status = when {
                     index < 4 -> OfflineAreaItemStatus.Downloaded(folderSize = "50 MB")
-                    index < 5 -> OfflineAreaItemStatus.Downloading(areaId = 48)
+                    index < 5 -> OfflineAreaItemStatus.Downloading(progress = .4f, progressDetail = "4/10")
                     else -> OfflineAreaItemStatus.NotDownloaded
                 }
             )

--- a/app/src/main/java/com/boolder/boolder/view/offlinephotos/OfflinePhotosViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/offlinephotos/OfflinePhotosViewModel.kt
@@ -3,21 +3,17 @@ package com.boolder.boolder.view.offlinephotos
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boolder.boolder.data.database.repository.AreaRepository
-import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
-import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItemStatus
 import com.boolder.boolder.offline.BoolderOfflineRepository
+import com.boolder.boolder.offline.OfflineAreaDownloader
+import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-abstract class OfflinePhotosViewModel : ViewModel() {
+abstract class OfflinePhotosViewModel : ViewModel(), OfflineAreaDownloader {
     abstract val screenState: StateFlow<ScreenState>
-
-    abstract fun onDownloadAreaClicked(areaId: Int)
-    abstract fun onDownloadTerminated(areaId: Int)
-    abstract fun onCancelDownload(areaId: Int)
-    abstract fun onDeleteAreaClicked(areaId: Int)
 
     data class ScreenState(val items: List<OfflineAreaItem> = emptyList())
 }
@@ -31,65 +27,38 @@ class OfflinePhotosViewModelImpl(
 
     init {
         viewModelScope.launch {
-            val items = areaRepository.getAllAreas()
-                .map { area ->
-                    OfflineAreaItem(
-                        area = area,
-                        status = boolderOfflineRepository.getStatusForAreaId(area.id)
-                    )
+            val allAreas = areaRepository.getAllAreas()
+
+            combine(
+                flows = allAreas.map { boolderOfflineRepository.getStatusForAreaIdFlow(it.id) },
+                transform = { allStatuses ->
+                    allStatuses.mapIndexed { index, offlineAreaItemStatus ->
+                        OfflineAreaItem(
+                            area = allAreas[index],
+                            status = offlineAreaItemStatus
+                        )
+                    }
                 }
-
-            val content = ScreenState(items = items)
-
-            screenState.emit(content)
+            ).collect { items ->
+                screenState.update { it.copy(items = items) }
+            }
         }
     }
 
-    override fun onDownloadAreaClicked(areaId: Int) {
-        updateItemToDownloadingState(areaId)
+    // region OfflineAreaDownloader
+
+    override fun onDownloadArea(areaId: Int) {
         boolderOfflineRepository.downloadArea(areaId)
     }
 
-    override fun onDownloadTerminated(areaId: Int) {
-        updateItems(areaId)
-    }
-
-    override fun onCancelDownload(areaId: Int) {
+    override fun onCancelAreaDownload(areaId: Int) {
         boolderOfflineRepository.cancelAreaDownload(areaId)
-        onDeleteAreaClicked(areaId)
+        onDeleteAreaPhotos(areaId)
     }
 
-    override fun onDeleteAreaClicked(areaId: Int) {
+    override fun onDeleteAreaPhotos(areaId: Int) {
         boolderOfflineRepository.deleteArea(areaId)
-        updateItems(areaId)
     }
 
-    private fun updateItemToDownloadingState(areaId: Int) {
-        val newItems = screenState.value.items.map { item ->
-            if (item.area.id == areaId) {
-                item.copy(
-                    status = OfflineAreaItemStatus.Downloading(areaId = areaId)
-                )
-            } else {
-                item
-            }
-        }
-
-        screenState.update { it.copy(items = newItems) }
-    }
-
-    private fun updateItems(areaId: Int) {
-        val newItems = screenState.value.items.map { item ->
-            if (item.area.id == areaId) {
-                item.copy(
-                    area = item.area,
-                    status = boolderOfflineRepository.getStatusForAreaId(item.area.id)
-                )
-            } else {
-                item
-            }
-        }
-
-        screenState.update { it.copy(items = newItems) }
-    }
+    // endregion OfflineAreaDownloader
 }

--- a/app/src/main/java/com/boolder/boolder/view/offlinephotos/model/OfflineAreaItem.kt
+++ b/app/src/main/java/com/boolder/boolder/view/offlinephotos/model/OfflineAreaItem.kt
@@ -10,5 +10,8 @@ data class OfflineAreaItem(
 sealed interface OfflineAreaItemStatus {
     data object NotDownloaded : OfflineAreaItemStatus
     data class Downloaded(val folderSize: String) : OfflineAreaItemStatus
-    data class Downloading(val areaId: Int) : OfflineAreaItemStatus
+    data class Downloading(
+        val progress: Float,
+        val progressDetail: String
+    ) : OfflineAreaItemStatus
 }

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -13,22 +13,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab_location"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_map_controls"
-            android:layout_marginBottom="@dimen/margin_map_controls"
-            android:contentDescription="@string/cd_find_my_position"
-            android:src="@drawable/ic_fab_near_me"
-            app:backgroundTint="?colorSurface"
-            app:borderWidth="0dp"
-            app:elevation="0dp"
-            app:fabSize="mini"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:tint="?colorOnSurface" />
-
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/controls_overlay_compose_view"
             android:layout_width="0dp"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -37,6 +37,12 @@
             android:id="@+id/show_poi"
             app:destination="@+id/dialog_poi" />
         <action
+            android:id="@+id/show_area_download_bottom_sheet"
+            app:destination="@+id/dialog_area_download" />
+        <action
+            android:id="@+id/navigate_to_download_manager"
+            app:destination="@+id/offline_photos_fragment" />
+        <action
             android:id="@+id/show_problem_photo_full_screen"
             app:destination="@+id/full_screen_photo_fragment" />
     </fragment>
@@ -241,6 +247,18 @@
         <argument
             android:name="google_maps_url"
             app:argType="string" />
+    </dialog>
+
+    <dialog
+        android:id="@+id/dialog_area_download"
+        android:name="com.boolder.boolder.view.map.areadownload.AreaDownloadBottomSheetDialog"
+        android:label="Area download bottom sheet dialog">
+        <argument
+            android:name="area_id"
+            app:argType="integer" />
+        <argument
+            android:name="nearby_area_ids"
+            app:argType="integer[]" />
     </dialog>
 
 </navigation>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -6,7 +6,6 @@
     <string name="tab_contribute">Contribuer</string>
 
     <string name="search_query_hint">Nom de voie ou secteur</string>
-    <string name="cd_find_my_position">Me localiser</string>
     <string name="cancel">Annuler</string>
     <string name="cancel_search">Annuler la recherche</string>
     <string name="cd_go_back">Retour</string>
@@ -98,10 +97,6 @@
     <string name="area_overview_delete_photos">Supprimer les photos</string>
     <string name="area_overview_download_in_progress">Téléchargement en cours…</string>
     <string name="area_overview_downloaded_photos">Photos téléchargées (%s)</string>
-    <string name="area_overview_photos_deletion_dialog_title">Attention</string>
-    <string name="area_overview_photos_deletion_dialog_text">Voulez-vous supprimer les photos téléchargées ?</string>
-    <string name="area_overview_photos_deletion_dialog_confirm_button">Supprimer</string>
-    <string name="area_overview_photos_deletion_dialog_cancel_button">Annuler</string>
     <string name="area_overview_error_cannot_display_area">Impossible d\'afficher les informations de ce secteur</string>
     <string name="area_circuit_beginner_friendly">Ce circuit convient aux débutants</string>
     <string name="area_circuit_dangerous">Ce circuit est dangereux : certains blocs sont très hauts et/ou avec une réception difficile</string>
@@ -151,7 +146,22 @@
 
     <string name="full_screen_photo_error">Cette photo ne peut être affichée</string>
 
+    <string name="area_download_sheet_title">Téléchargements</string>
+    <string name="area_download_sheet_nearby_areas">Autres secteurs proches</string>
+
+    <string name="photos_download_cancellation_dialog_title">Attention</string>
+    <string name="photos_download_cancellation_dialog_text">Voulez-vous annuler le téléchargement des photos ?</string>
+    <string name="photos_download_cancellation_dialog_confirm_button">Annuler le téléchargement</string>
+    <string name="photos_download_cancellation_dialog_cancel_button">Continuer à télécharger</string>
+    <string name="photos_download_deletion_dialog_title">Attention</string>
+    <string name="photos_download_deletion_dialog_text">Voulez-vous supprimer les photos téléchargées ?</string>
+    <string name="photos_download_deletion_dialog_confirm_button">Supprimer</string>
+    <string name="photos_download_deletion_dialog_cancel_button">Annuler</string>
+
     <string name="cd_circuit_previous_boulder_problem">Bloc précédent du circuit</string>
     <string name="cd_circuit_next_boulder_problem">Bloc suivant du circuit</string>
+    <string name="cd_download_area">Télécharger le secteur</string>
+    <string name="cd_downloaded_area">Les photos du secteur ont été téléchargées</string>
+    <string name="cd_find_my_position">Me localiser</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,6 @@
     <string name="tab_contribute">Contribute</string>
 
     <string name="search_query_hint">Problem or area name</string>
-    <string name="cd_find_my_position">Find my position</string>
     <string name="cancel">Cancel</string>
     <string name="cancel_search">Cancel search</string>
     <string name="cd_go_back">Go Back</string>
@@ -101,10 +100,6 @@
     <string name="area_overview_delete_photos">Delete photos</string>
     <string name="area_overview_download_in_progress">Download in progress…</string>
     <string name="area_overview_downloaded_photos">Downloaded photos (%s)</string>
-    <string name="area_overview_photos_deletion_dialog_title">Warning</string>
-    <string name="area_overview_photos_deletion_dialog_text">Are you sure to delete the downloaded photos?</string>
-    <string name="area_overview_photos_deletion_dialog_confirm_button">Delete</string>
-    <string name="area_overview_photos_deletion_dialog_cancel_button">Cancel</string>
     <string name="area_overview_error_cannot_display_area">Can\'t display information for this area</string>
     <string name="area_circuit_beginner_friendly">This circuit is beginner friendly</string>
     <string name="area_circuit_dangerous">This circuit is dangerous: some boulders are very high and/or with difficult landings</string>
@@ -153,8 +148,23 @@
     <string name="contribute_learn_more">Learn more about Boolder</string>
 
     <string name="full_screen_photo_error">This photo can\'t be displayed</string>
+    
+    <string name="area_download_sheet_title">Downloads</string>
+    <string name="area_download_sheet_nearby_areas">Other nearby areas</string>
+
+    <string name="photos_download_cancellation_dialog_title">Warning</string>
+    <string name="photos_download_cancellation_dialog_text">Do you want to cancel the photos download?</string>
+    <string name="photos_download_cancellation_dialog_confirm_button">Cancel download</string>
+    <string name="photos_download_cancellation_dialog_cancel_button">Keep going</string>
+    <string name="photos_download_deletion_dialog_title">Warning</string>
+    <string name="photos_download_deletion_dialog_text">Are you sure to delete the downloaded photos?</string>
+    <string name="photos_download_deletion_dialog_confirm_button">Delete</string>
+    <string name="photos_download_deletion_dialog_cancel_button">Cancel</string>
 
     <string name="cd_circuit_previous_boulder_problem">Circuit\'s previous boulder problem</string>
     <string name="cd_circuit_next_boulder_problem">Circuit\'s next boulder problem</string>
+    <string name="cd_download_area">Download the current area</string>
+    <string name="cd_downloaded_area">Area photos have been downloaded</string>
+    <string name="cd_find_my_position">Find my position</string>
 
 </resources>


### PR DESCRIPTION
In order to ease the download of the photos for an area, an additional FAB has been added. This FAB will appear when an area is focused on the map. A click on it will display a bottom sheet to manage the download of the current area, along with the nearby ones.

https://github.com/boolder-org/boolder-android/assets/8343416/c9171e6b-4af1-454a-ab6b-9091f268e8bd

