### PR TITLE
Avoid performing network request when photo exists locally

### DIFF
--- a/app/src/main/java/com/boolder/boolder/domain/DomainModule.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/DomainModule.kt
@@ -5,5 +5,6 @@ import org.koin.dsl.module
 
 val domainModule = module {
     factoryOf(::TopoDataAggregator)
+    factoryOf(::PhotoUriRetriever)
     factoryOf(::CircuitProblemsRetriever)
 }

--- a/app/src/main/java/com/boolder/boolder/domain/PhotoUriRetriever.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/PhotoUriRetriever.kt
@@ -1,0 +1,23 @@
+package com.boolder.boolder.domain
+
+import android.net.Uri
+import androidx.annotation.VisibleForTesting
+import com.boolder.boolder.data.network.repository.TopoRepository
+import com.boolder.boolder.offline.FileExplorer
+
+class PhotoUriRetriever(
+    private val topoRepository: TopoRepository,
+    private val fileExplorer: FileExplorer
+) {
+
+    suspend fun getPhotoUri(topoId: Int, areaId: Int): String? =
+        getLocalImageUri(topoId = topoId, areaId = areaId)
+            ?: topoRepository.getTopoPictureById(topoId)
+
+    @VisibleForTesting
+    fun getLocalImageUri(topoId: Int, areaId: Int): String? =
+        fileExplorer
+            .getTopoImageFile(areaId = areaId, topoId = topoId)
+            ?.let(Uri::fromFile)
+            ?.toString()
+}

--- a/app/src/main/java/com/boolder/boolder/domain/TopoDataAggregator.kt
+++ b/app/src/main/java/com/boolder/boolder/domain/TopoDataAggregator.kt
@@ -1,25 +1,21 @@
 package com.boolder.boolder.domain
 
-import android.net.Uri
 import com.boolder.boolder.data.database.entity.ProblemEntity
 import com.boolder.boolder.data.database.entity.circuitColorSafe
 import com.boolder.boolder.data.database.repository.LineRepository
 import com.boolder.boolder.data.database.repository.ProblemRepository
-import com.boolder.boolder.data.network.repository.TopoRepository
 import com.boolder.boolder.data.userdatabase.repository.TickedProblemRepository
 import com.boolder.boolder.domain.model.CircuitInfo
 import com.boolder.boolder.domain.model.CompleteProblem
 import com.boolder.boolder.domain.model.ProblemWithLine
 import com.boolder.boolder.domain.model.Topo
 import com.boolder.boolder.domain.model.TopoOrigin
-import com.boolder.boolder.offline.FileExplorer
 
 class TopoDataAggregator(
-    private val topoRepository: TopoRepository,
     private val problemRepository: ProblemRepository,
     private val lineRepository: LineRepository,
     private val tickedProblemRepository: TickedProblemRepository,
-    private val fileExplorer: FileExplorer,
+    private val photoUriRetriever: PhotoUriRetriever,
     private val circuitProblemsRetriever: CircuitProblemsRetriever
 ) {
 
@@ -38,13 +34,9 @@ class TopoDataAggregator(
         val mainLine = lineRepository.loadByProblemId(problemId)
         val topoId = mainLine?.topoId
 
-        val imageFileUri = topoId
-            ?.let { fileExplorer.getTopoImageFile(areaId = mainProblem.areaId, topoId = it) }
-            ?.let(Uri::fromFile)
-
-        val photoUrl = topoId?.let { topoRepository.getTopoPictureById(it) }
-
-        val photoUri = (imageFileUri ?: photoUrl).toString()
+        val photoUri = topoId?.let {
+            photoUriRetriever.getPhotoUri(topoId = it, areaId = mainProblem.areaId)
+        }
 
         val mainProblemAndLine = ProblemWithLine(
             problem = mainProblem.convert(tickStatus = mainProblemTickStatus),

--- a/app/src/test/java/com/boolder/boolder/domain/PhotoUriRetrieverTest.kt
+++ b/app/src/test/java/com/boolder/boolder/domain/PhotoUriRetrieverTest.kt
@@ -1,0 +1,83 @@
+package com.boolder.boolder.domain
+
+import com.boolder.boolder.data.network.repository.TopoRepository
+import com.boolder.boolder.offline.FileExplorer
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(MockitoJUnitRunner::class)
+class PhotoUriRetrieverTest {
+
+    @Mock private lateinit var topoRepository: TopoRepository
+    @Mock private lateinit var fileExplorer: FileExplorer
+
+    private lateinit var retriever: PhotoUriRetriever
+
+    @Before
+    fun setUp() {
+        retriever = PhotoUriRetriever(
+            topoRepository,
+            fileExplorer
+        ).let(::spy)
+    }
+
+    @Test
+    fun `getPhotoUri() should return the local image file URI`() = runTest {
+        // Given
+        val areaId = 0
+        val topoId = 0
+
+        retriever.stub { on { getLocalImageUri(areaId, topoId) } doReturn "file:///path/to/image" }
+
+        // When
+        val uri = retriever.getPhotoUri(areaId, topoId)
+
+        // Then
+        verify(topoRepository, never()).getTopoPictureById(anyInt())
+        assertEquals(uri, "file:///path/to/image" )
+    }
+
+    @Test
+    fun `getPhotoUri() should return the image URL`() = runTest {
+        // Given
+        val areaId = 0
+        val topoId = 0
+
+        retriever.stub { on { getLocalImageUri(areaId, topoId) } doReturn null }
+        topoRepository.stub { onBlocking { getTopoPictureById(topoId) } doReturn "https://www.boolder.com/path/to/image" }
+
+        // When
+        val uri = retriever.getPhotoUri(areaId, topoId)
+
+        // Then
+        assertEquals(uri, "https://www.boolder.com/path/to/image")
+    }
+
+    @Test
+    fun `getPhotoUri() should return null`() = runTest {
+        // Given
+        val areaId = 0
+        val topoId = 0
+
+        retriever.stub { on { getLocalImageUri(areaId, topoId) } doReturn null }
+        topoRepository.stub { onBlocking { getTopoPictureById(topoId) } doReturn null }
+
+        // When
+        val uri = retriever.getPhotoUri(areaId, topoId)
+
+        // Then
+        assertNull(uri)
+    }
+}


### PR DESCRIPTION
While refactoring the topo bottom sheet, I inadvertently extracted the photo URL fetch instruction to a value, with the side effect of always calling this instruction, even when not needed (when the photo has been downloaded and is available locally).
This commit fixes this behavior.

Resolves #152 