### PR TITLE
Show keyboard when accessing the search screen

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/search/SearchFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/search/SearchFragment.kt
@@ -1,10 +1,12 @@
 package com.boolder.boolder.view.search
 
+import android.content.Context
 import android.os.Bundle
 import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.ViewCompat
@@ -66,12 +68,20 @@ class SearchFragment : Fragment() {
                 .searchContainer
                 .updateLayoutParams<ViewGroup.MarginLayoutParams> { updateMargins(top = topMargin) }
 
+            binding.suggestionContainer
+                .updateLayoutParams<ViewGroup.MarginLayoutParams> { updateMargins(bottom = contentInsets.bottom) }
+
             binding.recyclerView.updatePadding(bottom = contentInsets.bottom)
 
             WindowInsetsCompat.CONSUMED
         }
 
-        binding.searchComponent.searchBar.requestFocus()
+        with(binding.searchComponent.searchBar) {
+            if (!requestFocus()) return@with
+
+            (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
+                .showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+        }
 
         binding.searchComponent.searchFirstIcon.apply {
             val drawable = ContextCompat.getDrawable(view.context, R.drawable.ic_arrow_back)

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -30,7 +30,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@+id/search_component">
 
         <TextView
             android:id="@+id/suggestion_title"


### PR DESCRIPTION
When going to the search screen, an additional tap on the search bar was needed in order to make the keyboard appearing, which was a small UX friction.

https://github.com/user-attachments/assets/e2b9ee6d-96d2-4a50-9939-25f6f5975031

Resolves #157 