### PR TITLE
Improve grade filter UX

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,12 +10,12 @@ plugins {
 
 android {
     namespace = "com.boolder.boolder"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.boolder.boolder"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 38 // bump when new version
         versionName = "1.30.0" // bump when new version
 
@@ -51,7 +51,7 @@ android {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.12"
+        kotlinCompilerExtensionVersion = "1.5.14"
     }
 }
 
@@ -70,7 +70,7 @@ dependencies {
     implementation("com.mapbox.maps:android:11.4.0")
 
     // Play Services
-    implementation("com.google.android.gms:play-services-location:21.2.0")
+    implementation("com.google.android.gms:play-services-location:21.3.0")
 
     // Database
     implementation("androidx.room:room-runtime:2.6.1")
@@ -85,7 +85,7 @@ dependencies {
     implementation("io.coil-kt:coil-compose:2.6.0")
 
     // Jetpack compose
-    val composeBom = platform("androidx.compose:compose-bom:2024.05.00")
+    val composeBom = platform("androidx.compose:compose-bom:2024.10.01")
     implementation(composeBom)
     androidTestImplementation(composeBom)
     implementation("androidx.compose.material3:material3")
@@ -95,14 +95,15 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-tooling-preview")
 
-    implementation("androidx.activity:activity-compose:1.9.0")
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("androidx.core:core-ktx:1.13.1")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
-    implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
+    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.2.0")
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.8.4")
+    implementation("androidx.navigation:navigation-ui-ktx:2.8.4")
     implementation("com.google.android.material:material:1.12.0")
 
     testImplementation("io.insert-koin:koin-test-junit4:3.5.6")
@@ -112,8 +113,8 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     testImplementation("junit:junit:4.13.2")
 
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
 
     // Work manager
-    implementation("androidx.work:work-runtime-ktx:2.9.0")
+    implementation("androidx.work:work-runtime-ktx:2.10.0")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,9 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-parcelize")
     id("com.google.devtools.ksp")
     kotlin("plugin.serialization")
@@ -47,11 +50,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
     }
 }
 

--- a/app/src/main/java/com/boolder/boolder/AppModule.kt
+++ b/app/src/main/java/com/boolder/boolder/AppModule.kt
@@ -1,6 +1,7 @@
 package com.boolder.boolder
 
 import androidx.work.WorkManager
+import com.boolder.boolder.data.datastore.dataStore
 import com.boolder.boolder.offline.BoolderOfflineRepository
 import com.boolder.boolder.offline.worker.BoolderWorkerFactory
 import org.koin.android.ext.koin.androidApplication
@@ -12,4 +13,5 @@ val appModule = module {
     factoryOf(::BoolderOfflineRepository)
     factory { WorkManager.getInstance(androidApplication()) }
     factory { androidApplication().resources }
+    single { androidApplication().dataStore }
 }

--- a/app/src/main/java/com/boolder/boolder/data/datastore/PreferenceDatastore.kt
+++ b/app/src/main/java/com/boolder/boolder/data/datastore/PreferenceDatastore.kt
@@ -1,0 +1,12 @@
+package com.boolder.boolder.data.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+
+val PREF_CUSTOM_GRADE_RANGE_MIN = stringPreferencesKey("pref_custom_grade_range_min")
+val PREF_CUSTOM_GRADE_RANGE_MAX = stringPreferencesKey("pref_custom_grade_range_max")
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")

--- a/app/src/main/java/com/boolder/boolder/view/compose/BoolderTheme.kt
+++ b/app/src/main/java/com/boolder/boolder/view/compose/BoolderTheme.kt
@@ -1,14 +1,17 @@
 package com.boolder.boolder.view.compose
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material.ripple.RippleAlpha
-import androidx.compose.material.ripple.RippleTheme
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RippleConfiguration
+import androidx.compose.material3.RippleDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BoolderTheme(
     content: @Composable () -> Unit
@@ -49,32 +52,17 @@ fun BoolderTheme(
         } else {
             boolderColorSchemeLight
         },
-        content = content
+        content = {
+            val rippleConfiguration = RippleConfiguration(
+                color = if (isSystemInDarkTheme()) Color.White else Color.Black,
+                rippleAlpha = RippleDefaults.RippleAlpha
+            )
+
+            CompositionLocalProvider(LocalRippleConfiguration provides rippleConfiguration) {
+                content()
+            }
+        }
     )
-}
-
-@Immutable
-object BoolderRippleTheme : RippleTheme {
-
-    @Composable
-    override fun defaultColor(): Color {
-        val darkTheme = isSystemInDarkTheme()
-
-        return RippleTheme.defaultRippleColor(
-            contentColor = if (darkTheme) Color.White else Color.Black,
-            lightTheme = !darkTheme
-        )
-    }
-
-    @Composable
-    override fun rippleAlpha(): RippleAlpha {
-        val darkTheme = isSystemInDarkTheme()
-
-        return RippleTheme.defaultRippleAlpha(
-            contentColor = if (darkTheme) Color.White else Color.Black,
-            lightTheme = !darkTheme
-        )
-    }
 }
 
 @Stable

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/MapHeaderLayout.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/MapHeaderLayout.kt
@@ -4,7 +4,6 @@ import androidx.annotation.DrawableRes
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
 import androidx.compose.foundation.layout.Box
@@ -98,7 +97,6 @@ fun MapHeaderLayout(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun FiltersRow(
     circuitState: MapViewModel.CircuitState?,
@@ -168,7 +166,7 @@ private fun FiltersRow(
             if (showCircuitFilterChip) {
                 item(key = circuitState?.circuitId) {
                     MapFilterChip(
-                        modifier = Modifier.animateItemPlacement(),
+                        modifier = Modifier.animateItem(),
                         selected = isCircuitFilterActive,
                         label = circuitState?.color?.localizedName()
                             ?: stringResource(id = R.string.circuits),
@@ -182,7 +180,7 @@ private fun FiltersRow(
 
             item(key = gradeState.gradeRangeButtonTitle) {
                 MapFilterChip(
-                    modifier = Modifier.animateItemPlacement(),
+                    modifier = Modifier.animateItem(),
                     selected = isGradeFilterActive,
                     label = gradeState.gradeRangeButtonTitle,
                     iconRes = R.drawable.ic_signal_cellular_alt,
@@ -192,7 +190,7 @@ private fun FiltersRow(
 
             item(key = "popular-filter") {
                 MapFilterChip(
-                    modifier = Modifier.animateItemPlacement(),
+                    modifier = Modifier.animateItem(),
                     selected = isPopularFilterActive,
                     label = stringResource(id = R.string.filter_popular),
                     iconRes = R.drawable.ic_favorite_border,
@@ -202,7 +200,7 @@ private fun FiltersRow(
 
             item(key = "projects-filter") {
                 MapFilterChip(
-                    modifier = Modifier.animateItemPlacement(),
+                    modifier = Modifier.animateItem(),
                     selected = isProjectsFilterActive,
                     label = stringResource(id = R.string.filter_projects),
                     iconRes = R.drawable.ic_star_outline,
@@ -212,7 +210,7 @@ private fun FiltersRow(
 
             item(key = "ticked-filter") {
                 MapFilterChip(
-                    modifier = Modifier.animateItemPlacement(),
+                    modifier = Modifier.animateItem(),
                     selected = isTickedFilterActive,
                     label = stringResource(id = R.string.filter_ticked),
                     iconRes = R.drawable.ic_check_circle,
@@ -237,6 +235,7 @@ private fun MapFilterResetChip(
         shape = CircleShape,
         contentPadding = PaddingValues(),
         colors = ButtonDefaults.elevatedButtonColors(
+            containerColor = MaterialTheme.colorScheme.surface,
             contentColor = MaterialTheme.colorScheme.onSurface
         ),
         onClick = onClick,
@@ -262,6 +261,7 @@ private fun MapFilterChip(
         selected = selected,
         shape = CircleShape,
         colors = FilterChipDefaults.elevatedFilterChipColors(
+            containerColor = MaterialTheme.colorScheme.surface,
             labelColor = MaterialTheme.colorScheme.onSurface,
             iconColor = MaterialTheme.colorScheme.onSurface
         ),

--- a/app/src/main/java/com/boolder/boolder/view/map/composable/MapTopBar.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/composable/MapTopBar.kt
@@ -1,9 +1,7 @@
 package com.boolder.boolder.view.map.composable
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.material.ripple.LocalRippleTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -11,7 +9,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.viewinterop.AndroidViewBinding
 import com.boolder.boolder.databinding.SearchComponentBinding
 import com.boolder.boolder.utils.previewgenerator.dummyOfflineAreaItem
-import com.boolder.boolder.view.compose.BoolderRippleTheme
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.offlinephotos.model.OfflineAreaItem
 
@@ -38,13 +35,11 @@ fun MapTopBar(
             }
         )
 
-        CompositionLocalProvider(LocalRippleTheme provides BoolderRippleTheme) {
-            AreaName(
-                offlineAreaItem = offlineAreaItem,
-                onHideAreaName = onHideAreaName,
-                onAreaInfoClicked = onAreaInfoClicked
-            )
-        }
+        AreaName(
+            offlineAreaItem = offlineAreaItem,
+            onHideAreaName = onHideAreaName,
+            onAreaInfoClicked = onAreaInfoClicked
+        )
     }
 }
 

--- a/app/src/main/java/com/boolder/boolder/view/map/filter/circuit/CircuitFilterLayout.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/filter/circuit/CircuitFilterLayout.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ripple.LocalRippleTheme
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -19,7 +18,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -35,7 +33,6 @@ import com.boolder.boolder.R
 import com.boolder.boolder.domain.model.Circuit
 import com.boolder.boolder.domain.model.CircuitColor
 import com.boolder.boolder.view.compose.BoolderOrange
-import com.boolder.boolder.view.compose.BoolderRippleTheme
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.compose.CircuitItem
 import com.mapbox.geojson.Point
@@ -106,12 +103,10 @@ private fun CircuitsContent(
     onCircuitSelected: (Int) -> Unit
 ) {
     Column {
-        CompositionLocalProvider(LocalRippleTheme provides BoolderRippleTheme) {
-            CircuitsList(
-                availableCircuits = availableCircuits,
-                onCircuitSelected = onCircuitSelected
-            )
-        }
+        CircuitsList(
+            availableCircuits = availableCircuits,
+            onCircuitSelected = onCircuitSelected
+        )
 
         BottomButtons(
             modifier = Modifier
@@ -162,7 +157,7 @@ private fun BottomButtons(
     ) {
         Button(
             colors = ButtonDefaults.outlinedButtonColors(),
-            border = ButtonDefaults.outlinedButtonBorder,
+            border = ButtonDefaults.outlinedButtonBorder(),
             onClick = onReset
         ) {
             Text(text = stringResource(id = R.string.reset))

--- a/app/src/main/java/com/boolder/boolder/view/map/filter/grade/GradesFilterLayout.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/filter/grade/GradesFilterLayout.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ripple.LocalRippleTheme
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenuItem
@@ -20,12 +19,12 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,7 +42,6 @@ import com.boolder.boolder.R
 import com.boolder.boolder.domain.model.ALL_GRADES
 import com.boolder.boolder.domain.model.GradeRange
 import com.boolder.boolder.domain.model.gradeRangeLevelDisplay
-import com.boolder.boolder.view.compose.BoolderRippleTheme
 import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.map.filter.grade.GradesFilterViewModel.Companion.QUICK_GRADE_RANGES
 
@@ -78,13 +76,11 @@ internal fun GradesFilterLayout(
             textAlign = TextAlign.Center
         )
 
-        CompositionLocalProvider(LocalRippleTheme provides BoolderRippleTheme) {
-            GradeRangesList(
-                gradeRanges = gradeRanges,
-                selectedGradeRange = selectedGradeRange,
-                onGradeRangeSelected = onGradeRangeSelected
-            )
-        }
+        GradeRangesList(
+            gradeRanges = gradeRanges,
+            selectedGradeRange = selectedGradeRange,
+            onGradeRangeSelected = onGradeRangeSelected
+        )
 
         CustomRangeSelectors(
             selectedGradeRange = selectedGradeRange,
@@ -192,9 +188,6 @@ private fun CustomRangeSelectors(
         val minGrade = selectedGradeRange?.min.orEmpty()
         val maxGrade = selectedGradeRange?.max.orEmpty()
 
-        val maxLowBoundIndex = ALL_GRADES.indexOf(maxGrade).coerceAtLeast(0)
-        val minHighBoundIndex = ALL_GRADES.indexOf(minGrade).coerceAtLeast(0)
-
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -205,20 +198,12 @@ private fun CustomRangeSelectors(
                 modifier = Modifier.weight(1f),
                 label = stringResource(id = R.string.grade_min),
                 value = minGrade,
-                grades = ALL_GRADES.subList(
-                    fromIndex = 0,
-                    toIndex = maxLowBoundIndex + 1
-                ),
                 onGradeSelected = onCustomLowBoundSelected
             )
             CustomRangeSelectorItem(
                 modifier = Modifier.weight(1f),
                 label = stringResource(id = R.string.grade_max),
                 value = maxGrade,
-                grades = ALL_GRADES.subList(
-                    fromIndex = minHighBoundIndex,
-                    toIndex = ALL_GRADES.size
-                ),
                 onGradeSelected = onCustomHighBoundSelected
             )
         }
@@ -230,7 +215,6 @@ private fun CustomRangeSelectors(
 private fun CustomRangeSelectorItem(
     label: String,
     value: String,
-    grades: List<String>,
     onGradeSelected: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -244,22 +228,24 @@ private fun CustomRangeSelectorItem(
             onExpandedChange = { expanded = !expanded}
         ) {
             TextField(
-                modifier = Modifier.menuAnchor(),
+                modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable),
                 label = { Text(text = label) },
                 value = value,
                 onValueChange = {},
                 readOnly = true,
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                 colors = TextFieldDefaults.colors(
+                    focusedContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = .2f),
                     unfocusedContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = .1f)
                 )
             )
 
             ExposedDropdownMenu(
                 expanded = expanded,
+                containerColor = MaterialTheme.colorScheme.background,
                 onDismissRequest = { expanded = false }
             ) {
-                grades.forEach { grade ->
+                ALL_GRADES.forEach { grade ->
                     DropdownMenuItem(
                         text = { Text(text = grade) },
                         onClick = {
@@ -285,7 +271,7 @@ private fun BottomButtons(
     ) {
         Button(
             colors = ButtonDefaults.outlinedButtonColors(),
-            border = ButtonDefaults.outlinedButtonBorder,
+            border = ButtonDefaults.outlinedButtonBorder(),
             onClick = onGradeRangeReset
         ) {
             Text(text = stringResource(id = R.string.reset))

--- a/app/src/main/java/com/boolder/boolder/view/map/filter/grade/GradesFilterViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/filter/grade/GradesFilterViewModel.kt
@@ -1,6 +1,5 @@
 package com.boolder.boolder.view.map.filter.grade
 
-import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
@@ -31,8 +30,6 @@ class GradesFilterViewModel(
         .map {
             val minGrade = it[PREF_CUSTOM_GRADE_RANGE_MIN]
             val maxGrade = it[PREF_CUSTOM_GRADE_RANGE_MAX]
-
-            Log.d("WANG", "New values: $minGrade, $maxGrade")
 
             if (minGrade == null || maxGrade == null) return@map DEFAULT_CUSTOM_RANGE
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,16 +2,16 @@
 buildscript {
     repositories { mavenCentral() }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-serialization:1.9.23"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.7.7"
+        classpath "org.jetbrains.kotlin:kotlin-serialization:1.9.24"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.8.4"
     }
 }
 
 plugins {
     id 'com.android.application' version '8.7.2' apply false
     id 'com.android.library' version '8.7.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.23' apply false
-    id 'com.google.devtools.ksp' version "1.9.23-1.0.20" apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.24' apply false
+    id 'com.google.devtools.ksp' version "1.9.24-1.0.20" apply false
     id 'androidx.room' version '2.6.1' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories { mavenCentral() }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-serialization:1.9.24"
+        classpath "org.jetbrains.kotlin:kotlin-serialization:2.0.21"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.8.4"
     }
 }
@@ -10,8 +10,9 @@ buildscript {
 plugins {
     id 'com.android.application' version '8.7.2' apply false
     id 'com.android.library' version '8.7.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.24' apply false
-    id 'com.google.devtools.ksp' version "1.9.24-1.0.20" apply false
+    id 'org.jetbrains.kotlin.android' version '2.0.21' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.0.21' apply false
+    id 'com.google.devtools.ksp' version "2.0.21-1.0.28" apply false
     id 'androidx.room' version '2.6.1' apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version '2.0.21' apply false
 }


### PR DESCRIPTION
Some users found experienced some friction when defining a custom grade range in the grade filter bottom sheet, as the selectable values for a given bound were limited by the other bound (for instance, a user could not select "5a+" as a minimum grade if the maximum was set to "5a").

This commit allows to select any grade, and will adjust the other bound of the grade range if necessary, in order to keep a coherent range.

Also, a previously set custom range will be defined as the new default custom range, so that a user who wants to always display the problems in his/her level will not have to set the range every time.

https://github.com/user-attachments/assets/c5b039d0-66f2-4687-a270-76bcde4a393d

Side note: I noticed the jank when the grades list appears, but it seems to be a bug from the material components library 😬 

Resolves #156 