### PR TITLE
Fix crash in `GradesFilterViewModel`

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/map/filter/grade/GradesFilterViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/filter/grade/GradesFilterViewModel.kt
@@ -26,6 +26,14 @@ class GradesFilterViewModel(
     private val preferencesDatastore: DataStore<Preferences>
 ) : ViewModel() {
 
+    private val _screenStateFlow = MutableStateFlow(
+        ScreenState(
+            gradeRanges = QUICK_GRADE_RANGES,
+            selectedGradeRange = requireNotNull(savedStateHandle.get<GradeRange>(ARG_GRADE_RANGE))
+        )
+    )
+    val screenStateFlow = _screenStateFlow.asStateFlow()
+
     private val customGradeRangeFlow = preferencesDatastore.data
         .map {
             val minGrade = it[PREF_CUSTOM_GRADE_RANGE_MIN]
@@ -45,14 +53,6 @@ class GradesFilterViewModel(
                 ?.takeIf {it.isCustom }
                 ?: DEFAULT_CUSTOM_RANGE
         )
-
-    private val _screenStateFlow = MutableStateFlow(
-        ScreenState(
-            gradeRanges = QUICK_GRADE_RANGES,
-            selectedGradeRange = requireNotNull(savedStateHandle.get<GradeRange>(ARG_GRADE_RANGE))
-        )
-    )
-    val screenStateFlow = _screenStateFlow.asStateFlow()
 
     private val _eventFlow = MutableSharedFlow<Event>()
     val eventFlow = _eventFlow.asSharedFlow()

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.9.0' apply false
-    id 'com.android.library' version '8.9.0' apply false
+    id 'com.android.application' version '8.9.1' apply false
+    id 'com.android.library' version '8.9.1' apply false
     id 'org.jetbrains.kotlin.android' version '2.0.21' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '2.0.21' apply false
     id 'com.google.devtools.ksp' version "2.0.21-1.0.28" apply false


### PR DESCRIPTION
The `_screenStateFlow` property was used in the definition of `customGradeRangeFlow`, but declared after, so it could lead to crashes if `_screenStateFlow` was not initialized yet, while `customGradeRangeFlow` was processing a new value.

The Android Gradle plugin version has also been updated.