### PR TITLE
Fix crash when no browser is found

### DIFF
--- a/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverFragment.kt
@@ -1,10 +1,12 @@
 package com.boolder.boolder.view.discover.discover
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
@@ -27,14 +29,16 @@ class DiscoverFragment : Fragment() {
         ComposeView(inflater.context).apply {
             setContent {
                 BoolderTheme {
-                    val screenState = viewModel.screenState.collectAsStateWithLifecycle().value
+                    val screenState by viewModel.screenState.collectAsStateWithLifecycle()
+                    val event by viewModel.events.collectAsStateWithLifecycle(null)
 
                     DiscoverScreen(
                         screenState = screenState,
                         onDiscoverHeaderItemClicked = ::onDiscoverHeaderItemClicked,
                         onAreaClicked = ::onAreaClicked,
                         onRateAppClicked = ::onOpenPlayStorePage,
-                        onContributeClicked = ::onOpenContributeWebPage
+                        onContributeClicked = ::onOpenContributeWebPage,
+                        event = event
                     )
                 }
             }
@@ -91,6 +95,10 @@ class DiscoverFragment : Fragment() {
     private fun openWebUrl(url: String) {
         val intent = Intent(Intent.ACTION_VIEW, url.toUri())
 
-        startActivity(intent)
+        try {
+            startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            viewModel.onNoBrowserAvailable(url)
+        }
     }
 }

--- a/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverScreen.kt
+++ b/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverScreen.kt
@@ -20,9 +20,13 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,8 +56,19 @@ internal fun DiscoverScreen(
     onAreaClicked: (Int) -> Unit,
     onRateAppClicked: () -> Unit,
     onContributeClicked: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    event: DiscoverViewModel.Event? = null
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    event?.let {
+        val message = when (event) {
+            is DiscoverViewModel.Event.NoBrowserAvailable -> stringResource(R.string.discover_snackbar_no_browser_found)
+        }
+
+        LaunchedEffect(event.key) { snackbarHostState.showSnackbar(message) }
+    }
+
     Scaffold(
         modifier = modifier
             .padding(bottom = dimensionResource(id = R.dimen.height_bottom_nav_bar))
@@ -65,6 +80,7 @@ internal fun DiscoverScreen(
                 }
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         content = {
             when (screenState) {
                 is DiscoverViewModel.ScreenState.Loading -> LoadingScreen()

--- a/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/boolder/boolder/view/discover/discover/DiscoverViewModel.kt
@@ -4,7 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boolder.boolder.data.database.repository.AreaRepository
 import com.boolder.boolder.domain.model.Area
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -15,6 +17,9 @@ class DiscoverViewModel(
 
     private val _screenState = MutableStateFlow<ScreenState>(ScreenState.Loading)
     val screenState = _screenState.asStateFlow()
+
+    private val _events = MutableSharedFlow<Event>()
+    val events = _events.asSharedFlow()
 
     init {
         viewModelScope.launch {
@@ -30,11 +35,23 @@ class DiscoverViewModel(
         }
     }
 
+    fun onNoBrowserAvailable(url: String) {
+        val event = Event.NoBrowserAvailable(url + "?" + System.currentTimeMillis())
+
+        viewModelScope.launch { _events.emit(event) }
+    }
+
     sealed interface ScreenState {
         data object Loading : ScreenState
         data class Content(
             val allAreas: List<Area>,
             val popularAreas: List<Area>
         ) : ScreenState
+    }
+
+    sealed interface Event {
+        val key: String
+
+        data class NoBrowserAvailable(override val key: String) : Event
     }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -117,6 +117,7 @@
     <string name="discover_section_all_areas">Tous les secteurs</string>
     <string name="discover_section_popular_areas">Populaires</string>
     <string name="discover_section_support">Envie d\'aider ?</string>
+    <string name="discover_snackbar_no_browser_found">Aucun navigateur trouvé, impossible d\'ouvrir le lien</string>
     <string name="discover_support_rate">Noter l\'appli</string>
     <string name="discover_support_contribute">Contribuer</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="discover_section_all_areas">All areas</string>
     <string name="discover_section_popular_areas">Popular</string>
     <string name="discover_section_support">Want to help?</string>
+    <string name="discover_snackbar_no_browser_found">No browser found, can\'t open the link</string>
     <string name="discover_support_rate">Rate the app</string>
     <string name="discover_support_contribute">Contribute</string>
 


### PR DESCRIPTION
A crash happened with the following stack trace:
```
Exception android.content.ActivityNotFoundException:
  at android.app.Instrumentation.checkStartActivityResult (Instrumentation.java:2436)
  at android.app.Instrumentation.execStartActivity (Instrumentation.java:2010)
  at android.app.Activity.startActivityForResult (Activity.java:5942)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.kt:675)
  at android.app.Activity.startActivityForResult (Activity.java:5899)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.kt:660)
  at android.app.Activity.startActivity (Activity.java:6402)
  at androidx.core.content.ContextCompat.startActivity (ContextCompat.java:297)
  at androidx.fragment.app.FragmentHostCallback.onStartActivityFromFragment (FragmentHostCallback.java:166)
  at androidx.fragment.app.Fragment.startActivity (Fragment.java:1448)
  at androidx.fragment.app.Fragment.startActivity (Fragment.java:1436)
  at com.boolder.boolder.view.discover.discover.DiscoverFragment.openWebUrl (DiscoverFragment.kt:94)
  at com.boolder.boolder.view.discover.discover.DiscoverFragment.openBeginnerGuideArticle (DiscoverFragment.kt:67)
  at com.boolder.boolder.view.discover.discover.DiscoverFragment.onDiscoverHeaderItemClicked (DiscoverFragment.kt:55)
  ...
```
showing that a user could not open a URL because no browser was found on his device.

To avoid crashing and provide a better user experience, a snackbar is now displayed indicating that no browser has been found.