### PR TITLE
Update Mapbox version to 11.9.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 
     //Mapbox
-    implementation("com.mapbox.maps:android:11.4.0")
+    implementation("com.mapbox.maps:android:11.9.0")
 
     // Play Services
     implementation("com.google.android.gms:play-services-location:21.3.0")
@@ -102,8 +102,8 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.10.1")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
-    implementation("androidx.core:core-ktx:1.15.0")
-    implementation("androidx.datastore:datastore-preferences:1.1.3")
+    implementation("androidx.core:core-ktx:1.16.0")
+    implementation("androidx.datastore:datastore-preferences:1.1.4")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
     implementation("androidx.navigation:navigation-fragment-ktx:2.8.9")

--- a/app/src/main/java/com/boolder/boolder/view/discover/driesfast/DriesFastFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/discover/driesfast/DriesFastFragment.kt
@@ -1,13 +1,11 @@
 package com.boolder.boolder.view.discover.driesfast
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
-import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.findNavController
@@ -32,8 +30,7 @@ class DriesFastFragment : Fragment() {
                     DriesFastScreen(
                         screenState = screenState,
                         onBackPressed = { findNavController().popBackStack() },
-                        onAreaClicked = ::onAreaClicked,
-                        onBleauWeatherClicked = ::onBleauWeatherClicked
+                        onAreaClicked = ::onAreaClicked
                     )
                 }
             }
@@ -46,14 +43,5 @@ class DriesFastFragment : Fragment() {
         )
 
         findNavController().navigate(direction)
-    }
-
-    private fun onBleauWeatherClicked() {
-        val intent = Intent(
-            Intent.ACTION_VIEW,
-            "https://www.facebook.com/people/Bleau-Meteo/100055389702633/".toUri()
-        )
-
-        startActivity(intent)
     }
 }

--- a/app/src/main/java/com/boolder/boolder/view/discover/driesfast/DriesFastScreen.kt
+++ b/app/src/main/java/com/boolder/boolder/view/discover/driesfast/DriesFastScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -21,8 +20,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -42,7 +43,6 @@ internal fun DriesFastScreen(
     screenState: DriesFastViewModel.ScreenState,
     onBackPressed: () -> Unit,
     onAreaClicked: (Int) -> Unit,
-    onBleauWeatherClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Scaffold(
@@ -71,8 +71,7 @@ internal fun DriesFastScreen(
                 is DriesFastViewModel.ScreenState.Content -> DriesFastScreenContent(
                     modifier = Modifier.padding(it),
                     screenState = screenState,
-                    onAreaClicked = onAreaClicked,
-                    onBleauWeatherClicked = onBleauWeatherClicked
+                    onAreaClicked = onAreaClicked
                 )
             }
         }
@@ -83,7 +82,6 @@ internal fun DriesFastScreen(
 private fun DriesFastScreenContent(
     screenState: DriesFastViewModel.ScreenState.Content,
     onAreaClicked: (Int) -> Unit,
-    onBleauWeatherClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -106,8 +104,7 @@ private fun DriesFastScreenContent(
         )
 
         UsefulLinkItem(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            onBleauWeatherClicked = onBleauWeatherClicked
+            modifier = Modifier.padding(horizontal = 16.dp)
         )
     }
 }
@@ -140,28 +137,28 @@ private fun WarningItem(
 
 @Composable
 private fun UsefulLinkItem(
-    onBleauWeatherClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val usefulLinkStr = stringResource(id = R.string.top_areas_dry_fast_useful_link)
 
-    ClickableText(
+    Text(
         modifier = modifier,
         text = buildAnnotatedString {
             append(usefulLinkStr)
             append(" ")
-            withStyle(
-                MaterialTheme.typography.bodyLarge.toSpanStyle()
-                    .copy(color = MaterialTheme.colorScheme.primary)
+            withLink(
+                LinkAnnotation.Url(
+                    url = "https://www.facebook.com/people/Bleau-Meteo/100055389702633/",
+                    styles = TextLinkStyles(style = MaterialTheme.typography.bodyLarge.toSpanStyle()
+                        .copy(color = MaterialTheme.colorScheme.primary)
+                    )
+                )
             ) {
                 append("Bleau Météo")
             }
         },
         style = MaterialTheme.typography.bodyLarge
-            .copy(color = MaterialTheme.colorScheme.onSurface.copy(alpha = .7f)),
-        onClick = { offset ->
-            if (offset > usefulLinkStr.length) onBleauWeatherClicked()
-        }
+            .copy(color = MaterialTheme.colorScheme.onSurface.copy(alpha = .7f))
     )
 }
 
@@ -175,8 +172,7 @@ private fun DriesFastScreenPreview(
         DriesFastScreen(
             screenState = screenState,
             onBackPressed = {},
-            onAreaClicked = {},
-            onBleauWeatherClicked = {}
+            onAreaClicked = {}
         )
     }
 }

--- a/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
@@ -276,7 +276,7 @@ class BoolderMap(
             sourceId = "problems",
             sourceLayerId = BoolderMapConfig.problemsSourceLayerId,
             featureId = featureId,
-            state = Value.fromJson("""{"selected": true}""").value!!,
+            state = Value(hashMapOf("selected" to Value(true))),
             callback = {
                 if (it.isError) return@setFeatureState
 
@@ -293,7 +293,7 @@ class BoolderMap(
                 sourceId = "problems",
                 sourceLayerId = BoolderMapConfig.problemsSourceLayerId,
                 featureId = it,
-                state = Value.fromJson("""{"selected": false}""").value!!,
+                state = Value(hashMapOf("selected" to Value(false))),
                 callback = {}
             )
         }
@@ -397,25 +397,25 @@ class BoolderMap(
         val topInset = insets.top + resources.getAreaBarAndFiltersHeight().toDouble()
         val defaultInset = resources.getDefaultMargin().toDouble()
 
-        val cameraOptions = mapboxMap.cameraForCoordinates(
+        mapboxMap.cameraForCoordinates(
             coordinates = coordinates,
             camera = CameraOptions.Builder().build(),
             coordinatesPadding = EdgeInsets(topInset, defaultInset, defaultInset, defaultInset),
             maxZoom = null,
             offset = null
-        )
+        ) { cameraOptions ->
+            val mapAnimationOption = MapAnimationOptions.mapAnimationOptions { duration(500L) }
 
-        val mapAnimationOption = MapAnimationOptions.mapAnimationOptions { duration(500L) }
+            mapboxMap.flyTo(
+                cameraOptions = cameraOptions,
+                animationOptions = mapAnimationOption,
+                animatorListener = animationEndListener {
+                    areaId ?: return@animationEndListener
 
-        mapboxMap.flyTo(
-            cameraOptions = cameraOptions,
-            animationOptions = mapAnimationOption,
-            animatorListener = animationEndListener {
-                areaId ?: return@animationEndListener
-
-                listener?.onAreaVisited(areaId)
-            }
-        )
+                    listener?.onAreaVisited(areaId)
+                }
+            )
+        }
     }
 
     private fun zoomToCircuitBounds(circuitCoordinates: List<Point>) {
@@ -423,19 +423,17 @@ class BoolderMap(
         val bottomInset = resources.getCircuitStartButtonHeight().toDouble()
         val defaultInset = resources.getDefaultMargin().toDouble()
 
-        val cameraOptions = mapboxMap.cameraForCoordinates(
+        mapboxMap.cameraForCoordinates(
             coordinates = circuitCoordinates,
             camera = CameraOptions.Builder().build(),
             coordinatesPadding = EdgeInsets(topInset, defaultInset, bottomInset, defaultInset),
             maxZoom = null,
             offset = null
-        ).coerceZoomAtLeast(15.0)
+        ) { cameraOptions ->
+            val mapAnimationOption = MapAnimationOptions.mapAnimationOptions { duration(500L) }
 
-        val mapAnimationOption = MapAnimationOptions.mapAnimationOptions {
-            duration(500L)
+            mapboxMap.flyTo(cameraOptions.coerceZoomAtLeast(15.0), mapAnimationOption)
         }
-
-        mapboxMap.flyTo(cameraOptions, mapAnimationOption)
     }
 
 

--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -433,21 +433,21 @@ class MapFragment : Fragment(), BoolderMapListener {
         val topInset = topInset + resources.getAreaBarAndFiltersHeight().toDouble()
         val defaultInset = resources.getDefaultMargin().toDouble()
 
-        val cameraOptions = mapView.mapboxMap.cameraForCoordinates(
+        mapView.mapboxMap.cameraForCoordinates(
             coordinates = listOf(southWest, northEast),
             camera = CameraOptions.Builder().build(),
             coordinatesPadding = EdgeInsets(topInset, defaultInset, defaultInset, defaultInset),
             maxZoom = null,
             offset = null
-        )
+        ) { cameraOptions ->
+            mapView.camera.flyTo(
+                cameraOptions = cameraOptions,
+                animationOptions = defaultMapAnimationOptions {},
+                animatorListener = animationEndListener { delayedVisitToArea(area.id) }
+            )
 
-        mapView.camera.flyTo(
-            cameraOptions = cameraOptions,
-            animationOptions = defaultMapAnimationOptions {},
-            animatorListener = animationEndListener { delayedVisitToArea(area.id) }
-        )
-
-        bottomSheetBehavior.state = STATE_HIDDEN
+            bottomSheetBehavior.state = STATE_HIDDEN
+        }
     }
 
     private fun flyToProblem(problem: Problem, origin: TopoOrigin) {

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.9.1' apply false
-    id 'com.android.library' version '8.9.1' apply false
+    id 'com.android.application' version '8.9.2' apply false
+    id 'com.android.library' version '8.9.2' apply false
     id 'org.jetbrains.kotlin.android' version '2.0.21' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '2.0.21' apply false
     id 'com.google.devtools.ksp' version "2.0.21-1.0.28" apply false


### PR DESCRIPTION
The current Mapbox version (`11.4.0`) had a bug in its linter, raising a false positive:
![Capture d’écran 2025-04-30 à 23 36 04](https://github.com/user-attachments/assets/1133e535-744b-49fc-ac40-7a2de19f0919)

In order to fix these errors, the library has been updated to version `11.9.0`, along with some warning fixes due to this version upgrade.