### PR TITLE
Support 16kb page sizes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 
     //Mapbox
-    implementation("com.mapbox.maps:android:11.9.0")
+    implementation("com.mapbox.maps:android-ndk27:11.13.3")
 
     // Play Services
     implementation("com.google.android.gms:play-services-location:21.3.0")

--- a/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/BoolderMap.kt
@@ -390,7 +390,7 @@ class BoolderMap(
     }
 
     // Triggered when user click on a Area or Cluster on Map
-    private fun zoomToAreaBounds(
+    fun zoomToAreaBounds(
         coordinates: List<Point>,
         areaId: Int?
     ) {

--- a/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
+++ b/app/src/main/java/com/boolder/boolder/view/map/MapFragment.kt
@@ -42,9 +42,7 @@ import com.boolder.boolder.view.compose.BoolderTheme
 import com.boolder.boolder.view.map.BoolderMap.BoolderMapListener
 import com.boolder.boolder.view.map.animator.animationEndListener
 import com.boolder.boolder.view.map.composable.MapControlsOverlay
-import com.boolder.boolder.view.map.extension.getAreaBarAndFiltersHeight
 import com.boolder.boolder.view.map.extension.getAreaBarHeight
-import com.boolder.boolder.view.map.extension.getDefaultMargin
 import com.boolder.boolder.view.map.extension.getTopoBottomSheetHeight
 import com.boolder.boolder.view.map.filter.circuit.CircuitFilterBottomSheetDialogFragment
 import com.boolder.boolder.view.map.filter.circuit.CircuitFilterBottomSheetDialogFragment.Companion.RESULT_CIRCUIT_ID
@@ -430,24 +428,10 @@ class MapFragment : Fragment(), BoolderMapListener {
             area.northEastLat.toDouble()
         )
 
-        val topInset = topInset + resources.getAreaBarAndFiltersHeight().toDouble()
-        val defaultInset = resources.getDefaultMargin().toDouble()
-
-        mapView.mapboxMap.cameraForCoordinates(
+        mapView.zoomToAreaBounds(
             coordinates = listOf(southWest, northEast),
-            camera = CameraOptions.Builder().build(),
-            coordinatesPadding = EdgeInsets(topInset, defaultInset, defaultInset, defaultInset),
-            maxZoom = null,
-            offset = null
-        ) { cameraOptions ->
-            mapView.camera.flyTo(
-                cameraOptions = cameraOptions,
-                animationOptions = defaultMapAnimationOptions {},
-                animatorListener = animationEndListener { delayedVisitToArea(area.id) }
-            )
-
-            bottomSheetBehavior.state = STATE_HIDDEN
-        }
+            areaId = area.id
+        )
     }
 
     private fun flyToProblem(problem: Problem, origin: TopoOrigin) {


### PR DESCRIPTION
Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes on 64-bit devices.

More info here: https://developer.android.com/guide/practices/page-sizes

As Mapbox has some native code, this commit updates this dependency to the last one allowing 16kb memory page sizes.
Also, the `zoomToAreaBounds()` has been made public in order to factorise some code in the `MapFragment`.